### PR TITLE
Add Agent Skills links and reorganize badge sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,20 +8,30 @@
 
 Never lose a brilliant solution, code snippet, or architectural decision again. SpecStory captures, indexes, and makes searchable every interaction you have with AI coding assistants across all your projects and tools.
 
-[![CLI Open Source](https://img.shields.io/badge/CLI-Open%20Source-brightgreen?style=flat-square)](https://github.com/specstoryai/getspecstory/tree/main/specstory-cli)
-[![Installs](https://img.shields.io/endpoint?url=https%3A%2F%2Fspecstory.com%2Fapi%2Fbadge%3Fstat%3Dinstalls&style=flat-square)](https://specstory.com/api/badge?stat=installs)
-[![Active Users](https://img.shields.io/endpoint?url=https%3A%2F%2Fspecstory.com%2Fapi%2Fbadge%3Fstat%3DactiveUsers&style=flat-square)](https://specstory.com/api/badge?stat=activeUsers)
-[![Sessions Saved](https://img.shields.io/endpoint?url=https%3A%2F%2Fspecstory.com%2Fapi%2Fbadge%3Fstat%3DsessionsSaved&style=flat-square)](https://specstory.com/api/badge?stat=sessionsSaved)
-[![Rules Generated](https://img.shields.io/endpoint?url=https%3A%2F%2Fspecstory.com%2Fapi%2Fbadge%3Fstat%3DrulesGenerated&style=flat-square)](https://specstory.com/api/badge?stat=rulesGenerated)
+<p align="left">
+  <strong>Install SpecStory ──▶ </strong>&nbsp;
+  <a href="https://specstory.com"><img src="https://img.shields.io/endpoint?url=https%3A%2F%2Fspecstory.com%2Fapi%2Fbadge%3Fstat%3Dinstalls&style=flat-square" alt="Installs" style="vertical-align: middle;"></a>
+  <a href="https://specstory.com"><img src="https://img.shields.io/endpoint?url=https%3A%2F%2Fspecstory.com%2Fapi%2Fbadge%3Fstat%3DactiveUsers&style=flat-square" alt="Active Users" style="vertical-align: middle;"></a>
+  <a href="https://specstory.com"><img src="https://img.shields.io/endpoint?url=https%3A%2F%2Fspecstory.com%2Fapi%2Fbadge%3Fstat%3DsessionsSaved&style=flat-square" alt="Sessions Saved" style="vertical-align: middle;"></a>
+  <a href="https://specstory.com"><img src="https://img.shields.io/endpoint?url=https%3A%2F%2Fspecstory.com%2Fapi%2Fbadge%3Fstat%3DrulesGenerated&style=flat-square" alt="Rules Generated" style="vertical-align: middle;"></a>
+</p>
 
 <p align="left">
-  <strong>Connect with us ──▶</strong>&nbsp;
+  <strong>Contribute to OSS ──▶</strong>&nbsp;
+  <a href="https://github.com/specstoryai/getspecstory/tree/main/specstory-cli"><img src="https://img.shields.io/badge/CLI-Open%20Source-brightgreen?style=flat-square" alt="CLI Open Source" style="vertical-align: middle;"></a>
+  <a href="https://github.com/specstoryai/agent-skills"><img src="https://img.shields.io/badge/Skills-Open%20Source-brightgreen?style=flat-square" alt="Skills Open Source" style="vertical-align: middle;"></a>
+</p>
+
+<p align="left">
+  <strong>Connect with us ───▶</strong>&nbsp;
   <a href="https://twitter.com/specstoryai"><img src="https://img.shields.io/badge/X-000000?style=flat-square&logoColor=white" alt="X" style="vertical-align: middle;"></a>
   <a href="https://www.linkedin.com/company/specstory"><img src="https://img.shields.io/badge/LinkedIn-0077B5?style=flat-square&logo=linkedin&logoColor=white" alt="LinkedIn" style="vertical-align: middle;"></a>
   <a href="https://specstory.slack.com/join/shared_invite/zt-2vq0274ck-MYS39rgOpDSmgfE1IeK9gg#/shared-invite/email"><img src="https://img.shields.io/badge/Slack-4A154B?style=flat-square&logo=slack&logoColor=white" alt="Slack" style="vertical-align: middle;"></a>
   <a href="https://discord.gg/E47yQyEUd3"><img src="https://img.shields.io/badge/Discord-5865F2?style=flat-square&logo=discord&logoColor=white" alt="Discord" style="vertical-align: middle;"></a>
   <a href="https://www.youtube.com/@specstory"><img src="https://img.shields.io/badge/YouTube-FF0000?style=flat-square&logo=youtube&logoColor=white" alt="YouTube" style="vertical-align: middle;"></a>
 </p>
+
+> 🔧 **[Agent Skills](https://github.com/specstoryai/agent-skills)** - Install skills to generate session summaries, fetch project stats, organize history, and more
 
 ## How It Works
 ```
@@ -39,9 +49,10 @@ Gemini CLI         ┘
 ## Workflow
 
 1. **Capture** - Extensions save every AI interaction locally to `.specstory/history/`
-2. **Sync (Optional)** - Only if logged in, sessions sync to cloud
-3. **Search** - Find conversations locally or across all projects in cloud
-4. **Share** - Export and share specific solutions with your team
+2. **Process** - Use [Agent Skills](https://github.com/specstoryai/agent-skills) to generate summaries, stats, and insights from your history
+3. **Sync (Optional)** - Only if logged in, sessions sync to cloud
+4. **Search** - Find conversations locally or across all projects in cloud
+5. **Share** - Export and share specific solutions with your team
 
 ## Supported Development Tools
 
@@ -112,6 +123,7 @@ SpecStory Cloud creates your personal AI coding knowledge base:
 ## Documentation & Support
 
 - 📚 **[Full Documentation](https://docs.specstory.com/overview)** - Complete guides and [Cloud API reference](https://docs.specstory.com/api-reference/introduction)
+- 🔧 **[Agent Skills](https://github.com/specstoryai/agent-skills)** - Generate summaries, stats, and insights from your `.specstory/history`
 - 🐛 **[Report Issues](https://github.com/specstoryai/getspecstory/issues)** - We actively monitor and respond
 - 📖 **[Contribute to Docs](https://github.com/specstoryai/docs/)** - PRs welcome!
 


### PR DESCRIPTION
- Add "Contribute to OSS" section with CLI and Skills badges
- Add "Install SpecStory" and "Connect with us" badge sections
- Add Agent Skills to Workflow step 2 (Process)
- Add Agent Skills to Documentation & Support section
- Add callout for Agent Skills below badges