### PR TITLE
fix: install.sh uses wrong filename prefix for Linux/Darwin

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -32,7 +32,7 @@ if [ -z "$VERSION" ]; then
 fi
 
 # Download and install
-FILENAME="getspecstory_${OS}_${ARCH}.tar.gz"
+FILENAME="SpecStoryCLI_${OS}_${ARCH}.tar.gz"
 DOWNLOAD_URL="https://github.com/$REPO/releases/download/$VERSION/$FILENAME"
 TMP_DIR=$(mktemp -d)
 


### PR DESCRIPTION
## Summary

The release assets are named `SpecStoryCLI_*`, but `install.sh` still constructs the old
`getspecstory_*` filename. That makes the install script download a GitHub 404 response and then
fail with:

`gzip: stdin: not in gzip format`

## Fix

Change the archive filename from:

`getspecstory_${OS}_${ARCH}.tar.gz`

to:

`SpecStoryCLI_${OS}_${ARCH}.tar.gz`

This matches the asset names produced by the current release workflow.