### PR TITLE
feat(claudecode): surface never-sent queued inputs in chat markdown

### DIFF
--- a/specstory-cli/pkg/providers/claudecode/agent_session.go
+++ b/specstory-cli/pkg/providers/claudecode/agent_session.go
@@ -108,6 +108,11 @@ func buildExchangesFromRecords(records []JSONLRecord, workspaceRoot string) ([]E
 	var currentExchange *Exchange
 	var exchangeStartTime string
 
+	// Text of every user message that actually reached the agent. A queued input
+	// that was later sent appears here verbatim, so we use this to skip it below
+	// (it already renders as a normal user prompt) and only surface never-sent ones.
+	deliveredUserTexts := collectDeliveredUserTexts(records)
+
 	for _, record := range records {
 		recordType, _ := record.Data["type"].(string)
 		timestamp, _ := record.Data["timestamp"].(string)
@@ -178,6 +183,32 @@ func buildExchangesFromRecords(records []JSONLRecord, workspaceRoot string) ([]E
 			msg := buildAgentMessage(record, workspaceRoot, isSidechain)
 			currentExchange.Messages = append(currentExchange.Messages, msg)
 			currentExchange.EndTime = timestamp
+
+		case "queue-operation":
+			// Text the user typed while the agent was busy (rescued in the parser).
+			// Only "enqueue" carries content; dequeue/remove are null lifecycle events.
+			if operation, _ := record.Data["operation"].(string); operation != "enqueue" {
+				continue
+			}
+			content, _ := record.Data["content"].(string)
+			trimmed := strings.TrimSpace(content)
+			if trimmed == "" {
+				continue
+			}
+			// Skip queued inputs that were actually sent — they already appear as a
+			// normal user prompt. Surface only what the user typed but never sent.
+			if deliveredUserTexts[trimmed] {
+				continue
+			}
+
+			// Render the never-sent input as its own user turn at this point in time.
+			if currentExchange != nil {
+				exchanges = append(exchanges, *currentExchange)
+			}
+			currentExchange = &Exchange{
+				StartTime: timestamp,
+				Messages:  []Message{buildQueuedInputMessage(record)},
+			}
 		}
 	}
 
@@ -302,6 +333,63 @@ func buildUserMessage(record JSONLRecord, isSidechain bool) Message {
 	}
 
 	return msg
+}
+
+// collectDeliveredUserTexts returns the trimmed text of every user message that
+// reached the agent, keyed for exact-match lookup. Used to tell a queued input that
+// was eventually sent (already rendered) from one that was typed but never sent.
+func collectDeliveredUserTexts(records []JSONLRecord) map[string]bool {
+	delivered := make(map[string]bool)
+	for _, record := range records {
+		if recordType, _ := record.Data["type"].(string); recordType != "user" {
+			continue
+		}
+		message, _ := record.Data["message"].(map[string]interface{})
+		if message == nil {
+			continue
+		}
+
+		var text string
+		switch content := message["content"].(type) {
+		case string:
+			text = content
+		case []interface{}:
+			var parts []string
+			for _, item := range content {
+				contentMap, ok := item.(map[string]interface{})
+				if !ok {
+					continue
+				}
+				if contentType, _ := contentMap["type"].(string); contentType == "text" {
+					if t, _ := contentMap["text"].(string); t != "" {
+						parts = append(parts, t)
+					}
+				}
+			}
+			text = strings.Join(parts, "\n")
+		}
+
+		if trimmed := strings.TrimSpace(text); trimmed != "" {
+			delivered[trimmed] = true
+		}
+	}
+	return delivered
+}
+
+// buildQueuedInputMessage builds a user Message for a never-sent queued input,
+// tagged via Metadata so the renderer can mark it distinctly.
+func buildQueuedInputMessage(record JSONLRecord) Message {
+	uuid, _ := record.Data["uuid"].(string)
+	timestamp, _ := record.Data["timestamp"].(string)
+	content, _ := record.Data["content"].(string)
+
+	return Message{
+		ID:        uuid,
+		Timestamp: timestamp,
+		Role:      "user",
+		Content:   []ContentPart{{Type: "text", Text: content}},
+		Metadata:  map[string]interface{}{"queued": true},
+	}
 }
 
 // buildAgentMessage creates a Message from an assistant JSONL record

--- a/specstory-cli/pkg/providers/claudecode/jsonl_parser.go
+++ b/specstory-cli/pkg/providers/claudecode/jsonl_parser.go
@@ -2,6 +2,8 @@ package claudecode
 
 import (
 	"bufio"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -446,8 +448,21 @@ func (p *JSONLParser) eliminateDuplicates(records []JSONLRecord) []JSONLRecord {
 	for _, record := range records {
 		uuid, ok := record.Data["uuid"].(string)
 		if !ok || uuid == "" {
-			// Skip records without uuid
-			continue
+			// "queue-operation" enqueue records hold text the user typed while the
+			// agent was busy (type-ahead). They carry no uuid/parentUuid, so they
+			// would be dropped here and never reach the DAG or the rendered chat.
+			// Rescue them with a synthetic uuid: with no parentUuid they become
+			// single-node roots that mergeDagsWithSameSessionId folds back into
+			// their session (by sessionId) and flattenDAG orders by timestamp.
+			// Whether each one actually renders is decided later in
+			// buildExchangesFromRecords (delivered ones are skipped there).
+			if isQueuedInputRecord(record) {
+				uuid = syntheticQueuedUUID(record)
+				record.Data["uuid"] = uuid
+			} else {
+				// Skip records without uuid
+				continue
+			}
 		}
 
 		// If we haven't seen this uuid before, add it
@@ -486,6 +501,30 @@ func (p *JSONLParser) eliminateDuplicates(records []JSONLRecord) []JSONLRecord {
 	})
 
 	return uniqueRecords
+}
+
+// isQueuedInputRecord reports whether a record is a queue-operation "enqueue"
+// carrying non-empty text — i.e. something the user typed while the agent was busy.
+func isQueuedInputRecord(record JSONLRecord) bool {
+	if recordType, _ := record.Data["type"].(string); recordType != "queue-operation" {
+		return false
+	}
+	if operation, _ := record.Data["operation"].(string); operation != "enqueue" {
+		return false
+	}
+	content, _ := record.Data["content"].(string)
+	return strings.TrimSpace(content) != ""
+}
+
+// syntheticQueuedUUID derives a deterministic uuid for a queued-input record so it
+// survives deduplication. Deterministic (sessionId+timestamp+content) keeps repeated
+// syncs idempotent rather than minting a new id each run.
+func syntheticQueuedUUID(record JSONLRecord) string {
+	sessionID, _ := record.Data["sessionId"].(string)
+	timestamp, _ := record.Data["timestamp"].(string)
+	content, _ := record.Data["content"].(string)
+	sum := sha256.Sum256([]byte(sessionID + "|" + timestamp + "|" + content))
+	return "queued-" + hex.EncodeToString(sum[:8])
 }
 
 // mergeDagsWithSameSessionId merges DAGs that have the same session ID

--- a/specstory-cli/pkg/providers/claudecode/queued_input_test.go
+++ b/specstory-cli/pkg/providers/claudecode/queued_input_test.go
@@ -1,0 +1,158 @@
+package claudecode
+
+import "testing"
+
+func userRecord(uuid, text, ts string) JSONLRecord {
+	return JSONLRecord{Data: map[string]interface{}{
+		"type":      "user",
+		"uuid":      uuid,
+		"timestamp": ts,
+		"sessionId": "s1",
+		"message":   map[string]interface{}{"role": "user", "content": text},
+	}}
+}
+
+func assistantRecord(uuid, text, ts string) JSONLRecord {
+	return JSONLRecord{Data: map[string]interface{}{
+		"type":      "assistant",
+		"uuid":      uuid,
+		"timestamp": ts,
+		"sessionId": "s1",
+		"message": map[string]interface{}{
+			"role":    "assistant",
+			"content": []interface{}{map[string]interface{}{"type": "text", "text": text}},
+		},
+	}}
+}
+
+func queueOpRecord(operation, content, ts string) JSONLRecord {
+	data := map[string]interface{}{
+		"type":      "queue-operation",
+		"operation": operation,
+		"timestamp": ts,
+		"sessionId": "s1",
+	}
+	if content != "" {
+		data["content"] = content
+	}
+	return JSONLRecord{Data: data}
+}
+
+func enqueueRecord(text, ts string) JSONLRecord {
+	return queueOpRecord("enqueue", text, ts)
+}
+
+// collect all text from a built session's exchanges, with whether it was tagged queued.
+func collectMessages(exchanges []Exchange) []struct {
+	text   string
+	queued bool
+} {
+	var out []struct {
+		text   string
+		queued bool
+	}
+	for _, ex := range exchanges {
+		for _, m := range ex.Messages {
+			var text string
+			for _, c := range m.Content {
+				if c.Type == "text" {
+					text += c.Text
+				}
+			}
+			q, _ := m.Metadata["queued"].(bool)
+			out = append(out, struct {
+				text   string
+				queued bool
+			}{text, q})
+		}
+	}
+	return out
+}
+
+func TestQueuedInput_NeverSentIsSurfacedAndTagged(t *testing.T) {
+	records := []JSONLRecord{
+		userRecord("u1", "start the task", "2026-06-16T06:00:00Z"),
+		assistantRecord("a1", "working on it", "2026-06-16T06:00:05Z"),
+		enqueueRecord("ffmpeg is a must have!", "2026-06-16T06:00:10Z"),
+	}
+
+	exchanges, err := buildExchangesFromRecords(records, "")
+	if err != nil {
+		t.Fatalf("buildExchangesFromRecords: %v", err)
+	}
+
+	msgs := collectMessages(exchanges)
+	var found bool
+	for _, m := range msgs {
+		if m.text == "ffmpeg is a must have!" {
+			found = true
+			if !m.queued {
+				t.Errorf("never-sent queued input should be tagged queued=true")
+			}
+		}
+	}
+	if !found {
+		t.Errorf("never-sent queued input %q was dropped; messages=%+v", "ffmpeg is a must have!", msgs)
+	}
+}
+
+func TestQueuedInput_DeliveredIsNotDuplicated(t *testing.T) {
+	// User queued "use conda" while busy; it was later sent and appears as a real
+	// user message. It must render exactly once, untagged.
+	records := []JSONLRecord{
+		userRecord("u1", "start", "2026-06-16T06:00:00Z"),
+		assistantRecord("a1", "ok", "2026-06-16T06:00:05Z"),
+		enqueueRecord("use conda", "2026-06-16T06:00:10Z"),
+		userRecord("u2", "use conda", "2026-06-16T06:00:20Z"),
+	}
+
+	exchanges, err := buildExchangesFromRecords(records, "")
+	if err != nil {
+		t.Fatalf("buildExchangesFromRecords: %v", err)
+	}
+
+	count := 0
+	for _, m := range collectMessages(exchanges) {
+		if m.text == "use conda" {
+			count++
+			if m.queued {
+				t.Errorf("delivered input should render as a normal (untagged) user message")
+			}
+		}
+	}
+	if count != 1 {
+		t.Errorf("delivered queued input rendered %d times, want 1 (no duplication)", count)
+	}
+}
+
+func TestIsQueuedInputRecord(t *testing.T) {
+	tests := []struct {
+		name   string
+		record JSONLRecord
+		want   bool
+	}{
+		{"enqueue with content", enqueueRecord("ffmpeg is a must have!", "2026-06-16T06:00:10Z"), true},
+		{"enqueue empty content", queueOpRecord("enqueue", "", "2026-06-16T06:00:10Z"), false},
+		{"dequeue", queueOpRecord("dequeue", "", "2026-06-16T06:00:11Z"), false},
+		{"remove", queueOpRecord("remove", "", "2026-06-16T06:00:12Z"), false},
+		{"non-queue record", userRecord("u1", "hi", "2026-06-16T06:00:00Z"), false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isQueuedInputRecord(tt.record); got != tt.want {
+				t.Errorf("isQueuedInputRecord = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSyntheticQueuedUUID_Deterministic(t *testing.T) {
+	r := enqueueRecord("ffmpeg is a must have!", "2026-06-16T06:00:10Z")
+	if got1, got2 := syntheticQueuedUUID(r), syntheticQueuedUUID(r); got1 != got2 {
+		t.Errorf("synthetic uuid must be deterministic: %q vs %q", got1, got2)
+	}
+	other := enqueueRecord("different text", "2026-06-16T06:00:10Z")
+	if syntheticQueuedUUID(r) == syntheticQueuedUUID(other) {
+		t.Error("different content should yield different synthetic uuids")
+	}
+}

--- a/specstory-cli/pkg/session/markdown.go
+++ b/specstory-cli/pkg/session/markdown.go
@@ -139,13 +139,19 @@ func renderRoleHeader(msg Message, useUTC bool) string {
 		sidechainMarker = " - sidechain"
 	}
 
+	// Queued input the user typed while the agent was busy but never actually sent.
+	queuedMarker := ""
+	if queued, ok := msg.Metadata["queued"].(bool); ok && queued {
+		queuedMarker = " - queued, not sent"
+	}
+
 	if msg.Role == "user" {
 		// User message - include timestamp if available
 		if msg.Timestamp != "" {
 			formattedTimestamp := formatTimestamp(msg.Timestamp, useUTC)
-			return fmt.Sprintf("_**User%s (%s)**_\n\n", sidechainMarker, formattedTimestamp)
+			return fmt.Sprintf("_**User%s%s (%s)**_\n\n", sidechainMarker, queuedMarker, formattedTimestamp)
 		}
-		return fmt.Sprintf("_**User%s**_\n\n", sidechainMarker)
+		return fmt.Sprintf("_**User%s%s**_\n\n", sidechainMarker, queuedMarker)
 	}
 
 	// Agent message - include model and timestamp if available

--- a/specstory-cli/pkg/session/queued_marker_test.go
+++ b/specstory-cli/pkg/session/queued_marker_test.go
@@ -1,0 +1,20 @@
+package session
+
+import "testing"
+
+func TestRenderRoleHeader_QueuedMarker(t *testing.T) {
+	queued := Message{
+		Role:      "user",
+		Timestamp: "2026-06-16T06:39:53Z",
+		Metadata:  map[string]interface{}{"queued": true},
+	}
+	header := renderRoleHeader(queued, true)
+	if want := "_**User - queued, not sent (2026-06-16 06:39:53Z)**_\n\n"; header != want {
+		t.Errorf("queued header = %q, want %q", header, want)
+	}
+
+	normal := Message{Role: "user", Timestamp: "2026-06-16T06:39:53Z"}
+	if header := renderRoleHeader(normal, true); header != "_**User (2026-06-16 06:39:53Z)**_\n\n" {
+		t.Errorf("non-queued user header should not carry the marker, got %q", header)
+	}
+}


### PR DESCRIPTION
## Problem
Text typed while the agent is busy (type-ahead) is recorded by Claude Code as `queue-operation` records (`operation: "enqueue"`), which carry no `uuid`/`parentUuid`. Since the DAG is keyed on `uuid`, `eliminateDuplicates` discards these records before rendering — so anything the user typed but didn't send is silently dropped from the markdown. (ESC interrupts, `[Request interrupted by user]`, are unaffected; only queued text is lost.)

## Fix
- **`jsonl_parser.go`** — rescue `enqueue` records with a deterministic synthetic uuid (`sessionId+timestamp+content` hash). With no `parentUuid` they become single-node roots that `mergeDagsWithSameSessionId` folds back into their session and `flattenDAG` orders by timestamp — i.e. they ride the existing pipeline into the correct chronological position.
- **`agent_session.go`** — render a queued input as its own user turn **only if its text never appears as a delivered user message** (exact-trim match), so queued inputs that were eventually sent are not duplicated. Tagged via `Message.Metadata["queued"]`.
- **`markdown.go`** — render the tag as `_**User - queued, not sent (ts)**_`, mirroring the existing sidechain marker.

The deterministic uuid keeps re-syncs/resumes idempotent (same input → same node, no duplication).

## Validation
On a real session: stock drops `ffmpeg is a must have!` (0 occurrences); patched surfaces it plus 17 other never-sent inputs at their correct positions, with delivered queued inputs rendered exactly once.

## Testing
- New unit tests (table-driven with `t.Run` subtests): queued input surfaced + tagged, delivered input not duplicated, `isQueuedInputRecord` classification, deterministic synthetic uuid.
- `gofmt`/`goimports` clean; `golangci-lint run ./...` → **0 issues**; `go test ./...` → all packages pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)