### PR TITLE
fix(markdown): skip rendering content-less messages (empty role rounds)

### DIFF
--- a/specstory-cli/pkg/session/empty_rounds_test.go
+++ b/specstory-cli/pkg/session/empty_rounds_test.go
@@ -1,0 +1,62 @@
+package session
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestGenerateMarkdown_SkipsEmptyAgentRounds(t *testing.T) {
+	// Mirrors how Claude Code splits one agent turn into several records: a
+	// signature-only thinking block (no renderable content) followed by the text.
+	sd := &SessionData{
+		Provider:  ProviderInfo{Name: "Claude Code"},
+		SessionID: "s1",
+		CreatedAt: "2026-06-16T04:08:17Z",
+		Exchanges: []Exchange{{
+			StartTime: "2026-06-16T04:08:00Z",
+			Messages: []Message{
+				{Role: "user", Timestamp: "2026-06-16T04:08:00Z", Content: []ContentPart{{Type: "text", Text: "hi"}}},
+				{Role: "agent", Timestamp: "2026-06-16T04:08:17Z"},                                                         // empty (signature-only thinking)
+				{Role: "agent", Timestamp: "2026-06-16T04:08:18Z", Content: []ContentPart{{Type: "text", Text: "hello!"}}}, // real text
+			},
+		}},
+	}
+
+	md, err := GenerateMarkdownFromAgentSession(sd, false, true)
+	if err != nil {
+		t.Fatalf("generate: %v", err)
+	}
+
+	if got := strings.Count(md, "_**Agent"); got != 1 {
+		t.Errorf("expected 1 agent header (empty one skipped), got %d\n---\n%s", got, md)
+	}
+	if !strings.Contains(md, "hello!") {
+		t.Error("real agent text was dropped")
+	}
+	// The single rendered agent turn must still be separated from the user turn.
+	if !strings.Contains(md, "---") {
+		t.Error("expected a separator between user and agent")
+	}
+}
+
+func TestHasRenderableContent(t *testing.T) {
+	tool := &ToolInfo{Name: "Bash"}
+	cases := []struct {
+		name string
+		msg  Message
+		want bool
+	}{
+		{"empty", Message{Role: "agent"}, false},
+		{"whitespace only", Message{Content: []ContentPart{{Type: "text", Text: "  \n"}}}, false},
+		{"text", Message{Content: []ContentPart{{Type: "text", Text: "hi"}}}, true},
+		{"thinking", Message{Content: []ContentPart{{Type: "thinking", Text: "hmm"}}}, true},
+		{"tool only", Message{Tool: tool}, true},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := hasRenderableContent(c.msg); got != c.want {
+				t.Errorf("hasRenderableContent = %v, want %v", got, c.want)
+			}
+		})
+	}
+}

--- a/specstory-cli/pkg/session/markdown.go
+++ b/specstory-cli/pkg/session/markdown.go
@@ -60,6 +60,14 @@ func GenerateMarkdownFromAgentSession(sessionData *SessionData, includeMessageID
 	prevRole := ""
 	for _, exchange := range sessionData.Exchanges {
 		for _, msg := range exchange.Messages {
+			// A single agent turn is split across several JSONL records (thinking,
+			// text, tool_use). Records with no text, no rendered thinking, and no
+			// tool — e.g. signature-only thinking blocks — would otherwise emit a
+			// bare role header with an empty body. Skip them, and only advance
+			// prevRole for messages we actually render so separators stay correct.
+			if !hasRenderableContent(msg) {
+				continue
+			}
 			markdown.WriteString(renderMessage(msg, prevRole, includeMessageIDs, useUTC))
 			prevRole = msg.Role
 		}
@@ -95,6 +103,21 @@ func formatTimestamp(timestamp string, useUTC bool) string {
 
 	// Use local timezone with offset: "2025-11-13 21:12:14-0700"
 	return t.Local().Format("2006-01-02 15:04:05-0700")
+}
+
+// hasRenderableContent reports whether a message would produce visible output —
+// a non-empty text/thinking part or a tool use. Messages with none are skipped so
+// they don't emit an empty role header.
+func hasRenderableContent(msg Message) bool {
+	if msg.Tool != nil {
+		return true
+	}
+	for _, part := range msg.Content {
+		if strings.TrimSpace(part.Text) != "" {
+			return true
+		}
+	}
+	return false
 }
 
 // renderMessage renders a single message with role header, content, and optional tool use


### PR DESCRIPTION
## Problem
A single agent turn is split across several JSONL records (a thinking block, the text, then `tool_use` records). Records with no text, no rendered thinking, and no tool — most commonly signature-only thinking blocks (`"thinking": ""`) — still produced a bare `_**Agent (ts)**_` header with an empty body. A single session can carry hundreds of these empty rounds.

## Fix
Skip any message with no renderable content (no non-empty text/thinking part and no tool) before rendering, advancing `prevRole` only for rendered messages so role separators stay correct.

## Validation
On a real ~1k-record session: **158 empty agent rounds removed**, while user turns (69), tool blocks (154), and assistant text are all preserved.

## Testing
- New unit tests (table-driven with `t.Run` subtests): empty rounds skipped while real content/separators preserved; `hasRenderableContent` across text / thinking / tool / empty / whitespace cases.
- `gofmt`/`goimports` clean; `golangci-lint run ./...` → **0 issues**; `go test ./...` → all packages pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)