### PR TITLE
fix(codex):respect CODEX_HOME when locating sessions

### DIFF
--- a/specstory-cli/pkg/providers/codexcli/path_utils.go
+++ b/specstory-cli/pkg/providers/codexcli/path_utils.go
@@ -9,6 +9,9 @@ import (
 
 // codexSessionsRoot returns the root directory where Codex stores session files.
 func codexSessionsRoot(homeDir string) string {
+	if codexHome := os.Getenv("CODEX_HOME"); codexHome != "" {
+		return filepath.Join(codexHome, "sessions")
+	}
 	return filepath.Join(homeDir, ".codex", "sessions")
 }
 

--- a/specstory-cli/pkg/providers/codexcli/provider_test.go
+++ b/specstory-cli/pkg/providers/codexcli/provider_test.go
@@ -256,7 +256,17 @@ func TestCodexSessionsRoot(t *testing.T) {
 		t.Errorf("codexSessionsRoot() = %q, want %q", got, want)
 	}
 }
+func TestCodexSessionsRootUsesCODEXHOME(t *testing.T) {
+	t.Setenv("CODEX_HOME", "/tmp/custom-codex")
 
+	got := codexSessionsRoot("/ignored")
+
+	want := filepath.Join("/tmp/custom-codex", "sessions")
+
+	if got != want {
+		t.Errorf("codexSessionsRoot() = %q, want %q", got, want)
+	}
+}
 func TestParseCodexCommand(t *testing.T) {
 	tests := []struct {
 		name          string


### PR DESCRIPTION
Fixes #136

The Codex provider was always using `~/.codex/sessions` and ignored custom `CODEX_HOME` values.

This change makes it respect `CODEX_HOME` when locating Codex sessions and adds a test to cover the behavior.
