### PR TITLE
Size code fences so tool output can't break out of the markdown

### DIFF
--- a/specstory-cli/pkg/mdfmt/fence.go
+++ b/specstory-cli/pkg/mdfmt/fence.go
@@ -1,0 +1,46 @@
+package mdfmt
+
+import (
+	"fmt"
+	"strings"
+)
+
+// CodeFence wraps content in a fenced code block whose backtick fence is long
+// enough that no backtick run inside content can prematurely close it.
+//
+// CommonMark closes a fenced block only on a line whose backtick run is at
+// least as long as the opening fence. Agent output (tool results, file
+// contents, diffs, README excerpts) routinely contains its own ``` fences; a
+// fixed 3-backtick wrapper lets those leak out — an unbalanced inner fence
+// opens a code block that is never closed and swallows the rest of the
+// document. Sizing the fence to one longer than the longest backtick run in
+// content (minimum 3) embeds arbitrary content safely and, unlike
+// backslash-escaping, leaves no artifact in the rendered output.
+//
+// lang is an optional info string (e.g. "text", "bash"); pass "" for none.
+// The result has no leading or trailing newline.
+func CodeFence(lang, content string) string {
+	fence := strings.Repeat("`", fenceLen(content))
+	return fmt.Sprintf("%s%s\n%s\n%s", fence, lang, content, fence)
+}
+
+// fenceLen returns the fence length needed to safely wrap content: at least 3,
+// and always strictly greater than the longest run of consecutive backticks in
+// content, so no line inside content can act as a closing fence.
+func fenceLen(content string) int {
+	longest, run := 0, 0
+	for _, r := range content {
+		if r == '`' {
+			run++
+			if run > longest {
+				longest = run
+			}
+		} else {
+			run = 0
+		}
+	}
+	if n := longest + 1; n > 3 {
+		return n
+	}
+	return 3
+}

--- a/specstory-cli/pkg/mdfmt/fence_test.go
+++ b/specstory-cli/pkg/mdfmt/fence_test.go
@@ -1,0 +1,92 @@
+package mdfmt
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestFenceLen(t *testing.T) {
+	cases := []struct {
+		content string
+		want    int
+	}{
+		{"", 3},
+		{"no backticks here", 3},
+		{"one ` backtick", 3},
+		{"two `` backticks", 3},
+		{"a ``` fence", 4},
+		{"```text\nhi\n```", 4},
+		{"a ```` four-run", 5},
+		{"```sql\n```\n````", 5}, // longest run is 4
+	}
+	for _, c := range cases {
+		if got := fenceLen(c.content); got != c.want {
+			t.Errorf("fenceLen(%q) = %d, want %d", c.content, got, c.want)
+		}
+	}
+}
+
+// assertSingleBlock verifies that result is one well-formed fenced code block:
+// the first line opens the fence, the last line closes it with the same number
+// of backticks, and no interior line could prematurely close it.
+func assertSingleBlock(t *testing.T, content, result string) {
+	t.Helper()
+	lines := strings.Split(result, "\n")
+	if len(lines) < 2 {
+		t.Fatalf("result has too few lines: %q", result)
+	}
+	open := lines[0]
+	fence := open[:len(open)-len(strings.TrimLeft(open, "`"))]
+	if len(fence) < 3 {
+		t.Fatalf("opening fence too short: %q", open)
+	}
+	if last := lines[len(lines)-1]; last != fence {
+		t.Errorf("closing line %q != opening fence %q", last, fence)
+	}
+	// No interior line may be a run of >= len(fence) backticks (which would
+	// close the block early and leak the rest of the document).
+	for _, ln := range lines[1 : len(lines)-1] {
+		trimmed := strings.TrimRight(ln, " ")
+		if trimmed != "" && strings.Trim(trimmed, "`") == "" && len(trimmed) >= len(fence) {
+			t.Errorf("interior line %q would close a %d-backtick fence", ln, len(fence))
+		}
+	}
+	if !strings.Contains(result, content) {
+		t.Errorf("result does not contain original content verbatim")
+	}
+}
+
+func TestCodeFence_PlainContent(t *testing.T) {
+	r := CodeFence("text", "hello\nworld")
+	if !strings.HasPrefix(r, "```text\n") {
+		t.Errorf("expected 3-backtick text fence, got %q", r)
+	}
+	assertSingleBlock(t, "hello\nworld", r)
+}
+
+func TestCodeFence_EmbeddedFenceDoesNotBreakOut(t *testing.T) {
+	// The real-world fold: tool output that itself contains code fences,
+	// truncated mid-block so the inner fences are unbalanced.
+	content := "intro\n```sql\nSELECT 1\n```\nmid\n```bash\necho hi\n```\ntail:\n```"
+	r := CodeFence("text", content)
+	if !strings.HasPrefix(r, "````text\n") {
+		t.Errorf("expected 4-backtick fence for ```-containing content, got prefix %q", r[:min(12, len(r))])
+	}
+	assertSingleBlock(t, content, r)
+}
+
+func TestCodeFence_FourBacktickRun(t *testing.T) {
+	content := "a ```` b" // 4-run inside
+	r := CodeFence("", content)
+	if !strings.HasPrefix(r, "`````\n") {
+		t.Errorf("expected 5-backtick fence, got prefix %q", r[:min(8, len(r))])
+	}
+	assertSingleBlock(t, content, r)
+}
+
+func TestCodeFence_NoBackslashArtifact(t *testing.T) {
+	r := CodeFence("text", "```\ncode\n```")
+	if strings.Contains(r, "\\```") {
+		t.Errorf("CodeFence should not inject backslash escapes, got %q", r)
+	}
+}

--- a/specstory-cli/pkg/providers/claudecode/agent_session.go
+++ b/specstory-cli/pkg/providers/claudecode/agent_session.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/specstoryai/getspecstory/specstory-cli/pkg/mdfmt"
 	"github.com/specstoryai/getspecstory/specstory-cli/pkg/spi"
 	"github.com/specstoryai/getspecstory/specstory-cli/pkg/spi/schema"
 )
@@ -527,14 +528,16 @@ func formatToolAsMarkdown(tool *ToolInfo, workspaceRoot string) string {
 	if tool.Output != nil {
 		// Check for error first
 		if isError, ok := tool.Output["is_error"].(bool); ok && isError {
-			// Blank line before code fence helps parsers inside <details> tags
-			markdown.WriteString("\n```text\n")
+			cleaned := ""
 			if content, ok := tool.Output["content"].(string); ok {
-				cleaned := stripSystemReminders(content)
+				cleaned = stripSystemReminders(content)
 				cleaned = stripANSIEscapeSequences(cleaned)
-				markdown.WriteString(cleaned)
 			}
-			markdown.WriteString("\n```\n")
+			// Blank line before code fence helps parsers inside <details> tags.
+			// CodeFence sizes the fence so embedded ``` in output can't break out.
+			markdown.WriteString("\n")
+			markdown.WriteString(mdfmt.CodeFence("text", cleaned))
+			markdown.WriteString("\n")
 		} else {
 			// Regular result
 			if content, ok := tool.Output["content"].(string); ok {
@@ -550,16 +553,17 @@ func formatToolAsMarkdown(tool *ToolInfo, workspaceRoot string) string {
 						fmt.Fprintf(&markdown, "\n**Answer:** %s\n", answer)
 					} else if cleaned != "" {
 						// Fallback to code block if parsing fails
-						markdown.WriteString("\n```text\n")
-						markdown.WriteString(cleaned)
-						markdown.WriteString("\n```\n")
+						markdown.WriteString("\n")
+						markdown.WriteString(mdfmt.CodeFence("text", cleaned))
+						markdown.WriteString("\n")
 					}
 				} else if strings.TrimSpace(cleaned) != TodoWriteSuccessMessage && cleaned != "" {
 					// Skip TodoWrite success messages
-					// Blank line before code fence helps parsers inside <details> tags
-					markdown.WriteString("\n```text\n")
-					markdown.WriteString(cleaned)
-					markdown.WriteString("\n```\n")
+					// Blank line before code fence helps parsers inside <details> tags.
+					// CodeFence sizes the fence so embedded ``` in output can't break out.
+					markdown.WriteString("\n")
+					markdown.WriteString(mdfmt.CodeFence("text", cleaned))
+					markdown.WriteString("\n")
 				}
 			}
 		}

--- a/specstory-cli/pkg/providers/claudecode/fence_output_test.go
+++ b/specstory-cli/pkg/providers/claudecode/fence_output_test.go
@@ -1,0 +1,59 @@
+package claudecode
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestFormatToolAsMarkdown_OutputWithCodeFences reproduces the real-world fold:
+// a tool whose output contains its own ``` fences (e.g. `cat README.md`),
+// truncated so the inner fences are unbalanced. The wrapper must size up so the
+// embedded fences cannot break out and swallow the rest of the document.
+func TestFormatToolAsMarkdown_OutputWithCodeFences(t *testing.T) {
+	tool := &ToolInfo{
+		Name:  "Bash",
+		Input: map[string]interface{}{"command": "cat README.md"},
+		Output: map[string]interface{}{
+			"content": "```sql\nCREATE TABLE x\n```\nmid text\n```bash\necho hi\n```\ntrailing open:\n```",
+		},
+	}
+
+	result := formatToolAsMarkdown(tool, "/workspace")
+
+	// Output is wrapped in a >=4 backtick fence so embedded ``` can't break out.
+	if !strings.Contains(result, "````text\n") {
+		t.Fatalf("expected a 4-backtick text fence wrapping the output; got:\n%s", result)
+	}
+	// The 4-backtick wrapper must be balanced: exactly one open and one close.
+	if n := strings.Count(result, "````"); n != 2 {
+		t.Errorf("expected exactly 2 four-backtick fences (open+close), got %d:\n%s", n, result)
+	}
+	// Embedded fenced content is preserved verbatim — no backslash artifact.
+	if !strings.Contains(result, "```sql\nCREATE TABLE x\n```") {
+		t.Errorf("embedded fenced content not preserved verbatim:\n%s", result)
+	}
+	if strings.Contains(result, "\\```") {
+		t.Errorf("output should not contain backslash-escaped fences:\n%s", result)
+	}
+}
+
+// TestFormatToolAsMarkdown_ErrorOutputWithCodeFences covers the is_error branch,
+// which shares the same wrapping path.
+func TestFormatToolAsMarkdown_ErrorOutputWithCodeFences(t *testing.T) {
+	tool := &ToolInfo{
+		Name:  "Bash",
+		Input: map[string]interface{}{"command": "false"},
+		Output: map[string]interface{}{
+			"is_error": true,
+			"content":  "traceback:\n```\nboom\n```",
+		},
+	}
+
+	result := formatToolAsMarkdown(tool, "/workspace")
+	if !strings.Contains(result, "````text\n") {
+		t.Fatalf("expected a 4-backtick text fence for error output; got:\n%s", result)
+	}
+	if n := strings.Count(result, "````"); n != 2 {
+		t.Errorf("expected balanced 4-backtick fences, got %d:\n%s", n, result)
+	}
+}

--- a/specstory-cli/pkg/providers/codexcli/agent_session.go
+++ b/specstory-cli/pkg/providers/codexcli/agent_session.go
@@ -6,6 +6,7 @@ import (
 	"log/slog"
 	"strings"
 
+	"github.com/specstoryai/getspecstory/specstory-cli/pkg/mdfmt"
 	"github.com/specstoryai/getspecstory/specstory-cli/pkg/spi"
 	"github.com/specstoryai/getspecstory/specstory-cli/pkg/spi/schema"
 )
@@ -541,7 +542,7 @@ func formatToolWithSummary(tool *ToolInfo, workspaceRoot string) (string, string
 				if len(cleaned) > 5000 {
 					cleaned = cleaned[:5000] + "\n... (truncated)"
 				}
-				formattedMd.WriteString("```\n" + cleaned + "\n```")
+				formattedMd.WriteString(mdfmt.CodeFence("", cleaned))
 			}
 		}
 	}

--- a/specstory-cli/pkg/providers/codexcli/markdown_tools.go
+++ b/specstory-cli/pkg/providers/codexcli/markdown_tools.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
+
+	"github.com/specstoryai/getspecstory/specstory-cli/pkg/mdfmt"
 )
 
 // Todo status constants (used by formatUpdatePlan)
@@ -85,7 +87,7 @@ func formatShellWithSummary(argumentsJSON string) (string, string) {
 	// Multi-line commands go in body with bash code fence
 	// Single-line commands go in summary with inline backticks
 	if strings.Contains(command, "\n") {
-		return "", fmt.Sprintf("```bash\n%s\n```", command)
+		return "", mdfmt.CodeFence("bash", command)
 	}
 	return fmt.Sprintf("`%s`", command), ""
 }
@@ -124,9 +126,8 @@ func capitalizeFirst(s string) string {
 func writePatchSection(result *strings.Builder, operation, filename string, patchContent *strings.Builder) {
 	if patchContent.Len() > 0 {
 		fmt.Fprintf(result, "**%s: `%s`**\n\n", capitalizeFirst(operation), filename)
-		result.WriteString("```diff\n")
-		result.WriteString(patchContent.String())
-		result.WriteString("```\n\n")
+		result.WriteString(mdfmt.CodeFence("diff", strings.TrimRight(patchContent.String(), "\n")))
+		result.WriteString("\n\n")
 	}
 }
 
@@ -237,9 +238,9 @@ func formatCustomToolCall(toolName string, input string) string {
 		if input != "" {
 			// Show first 200 characters if input is long
 			if len(input) > 200 {
-				return fmt.Sprintf("\n\nInput (truncated): ```\n%s\n...\n```\n", input[:200])
+				return "\n\nInput (truncated): " + mdfmt.CodeFence("", input[:200]+"\n...") + "\n"
 			} else {
-				return fmt.Sprintf("\n\nInput: ```\n%s\n```\n", input)
+				return "\n\nInput: " + mdfmt.CodeFence("", input) + "\n"
 			}
 		}
 		return ""

--- a/specstory-cli/pkg/providers/cursorcli/markdown_tools.go
+++ b/specstory-cli/pkg/providers/cursorcli/markdown_tools.go
@@ -5,6 +5,8 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
+
+	"github.com/specstoryai/getspecstory/specstory-cli/pkg/mdfmt"
 )
 
 // getLanguageFromExtension returns the language identifier for syntax highlighting based on file extension
@@ -65,11 +67,8 @@ func formatWriteTool(args map[string]interface{}) string {
 	// Get language for syntax highlighting
 	lang := getLanguageFromExtension(filePath)
 
-	// Escape triple backticks in content to prevent breaking the code block
-	escapedContent := strings.ReplaceAll(contents, "```", "\\```")
-
-	// Add content in triple backticks with language hint
-	return fmt.Sprintf("```%s\n%s\n```", lang, escapedContent)
+	// Fence is sized so embedded ``` in content can't break the code block.
+	return mdfmt.CodeFence(lang, contents)
 }
 
 // formatStrReplaceTool formats StrReplace tool usage with git diff style output
@@ -88,26 +87,20 @@ func formatStrReplaceTool(args map[string]interface{}) string {
 		oldLines := strings.Split(oldString, "\n")
 		newLines := strings.Split(newString, "\n")
 
-		// Format as a diff
-		result.WriteString("```diff\n")
-
-		// Add file path as a header if available
+		// Build the diff body, then wrap in a fence sized so embedded ``` (e.g.
+		// when editing a markdown file) can't break out of the code block.
+		var body strings.Builder
 		if filePath != "" {
-			fmt.Fprintf(&result, "--- %s\n", filePath)
-			fmt.Fprintf(&result, "+++ %s\n", filePath)
+			fmt.Fprintf(&body, "--- %s\n", filePath)
+			fmt.Fprintf(&body, "+++ %s\n", filePath)
 		}
-
-		// Add old lines with - prefix
 		for _, line := range oldLines {
-			fmt.Fprintf(&result, "-%s\n", line)
+			fmt.Fprintf(&body, "-%s\n", line)
 		}
-
-		// Add new lines with + prefix
 		for _, line := range newLines {
-			fmt.Fprintf(&result, "+%s\n", line)
+			fmt.Fprintf(&body, "+%s\n", line)
 		}
-
-		result.WriteString("```")
+		result.WriteString(mdfmt.CodeFence("diff", strings.TrimRight(body.String(), "\n")))
 	} else {
 		// Fallback if arguments are missing
 		if filePath != "" {
@@ -277,14 +270,8 @@ func formatToolResult(result string) string {
 		return ""
 	}
 
-	var output strings.Builder
-
-	// Escape triple backticks in result to prevent breaking the code block
-	escapedResult := strings.ReplaceAll(result, "```", "\\```")
-
-	fmt.Fprintf(&output, "```\n%s\n```", escapedResult)
-
-	return output.String()
+	// Fence is sized so embedded ``` in the result can't break the code block.
+	return mdfmt.CodeFence("", result)
 }
 
 // Todo status constants

--- a/specstory-cli/pkg/providers/cursorcli/markdown_tools_test.go
+++ b/specstory-cli/pkg/providers/cursorcli/markdown_tools_test.go
@@ -146,12 +146,12 @@ func TestFormatWriteTool(t *testing.T) {
 			expected: "```javascript\nfunction hello() {\n  console.log('Hello');\n}\n```",
 		},
 		{
-			name: "Content with triple backticks (needs escaping)",
+			name: "Content with triple backticks (widens fence)",
 			args: map[string]interface{}{
 				"path":     "README.md",
 				"contents": "# Example\n\n```js\ncode here\n```\n\nMore text",
 			},
-			expected: "```markdown\n# Example\n\n\\```js\ncode here\n\\```\n\nMore text\n```",
+			expected: "````markdown\n# Example\n\n```js\ncode here\n```\n\nMore text\n````",
 		},
 		{
 			name: "File path only, no contents",
@@ -799,9 +799,9 @@ func TestFormatToolResult(t *testing.T) {
 			expected: "```\nCreated file: test.js\nWrote 50 lines\nOperation successful\n```",
 		},
 		{
-			name:     "Result with triple backticks (needs escaping)",
+			name:     "Result with triple backticks (widens fence)",
 			result:   "Error in code:\n```\nerror here\n```",
-			expected: "```\nError in code:\n\\```\nerror here\n\\```\n```",
+			expected: "````\nError in code:\n```\nerror here\n```\n````",
 		},
 		{
 			name:     "Empty result",

--- a/specstory-cli/pkg/providers/deepseektui/markdown_tools.go
+++ b/specstory-cli/pkg/providers/deepseektui/markdown_tools.go
@@ -8,6 +8,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/specstoryai/getspecstory/specstory-cli/pkg/mdfmt"
 	"github.com/specstoryai/getspecstory/specstory-cli/pkg/spi"
 )
 
@@ -77,7 +78,7 @@ func formatToolOutput(tool *ToolInfo) string {
 		return ""
 	}
 	if strings.Contains(content, "\n") {
-		return fmt.Sprintf("Output:\n```text\n%s\n```", content)
+		return fmt.Sprintf("Output:\n%s", mdfmt.CodeFence("text", content))
 	}
 	return fmt.Sprintf("Output: %s", content)
 }
@@ -271,7 +272,7 @@ func renderApplyPatch(args map[string]any) string {
 	if patch == "" {
 		return renderGenericJSON(args)
 	}
-	return fmt.Sprintf("```diff\n%s\n```", strings.TrimSpace(patch))
+	return mdfmt.CodeFence("diff", strings.TrimSpace(patch))
 }
 
 func renderTodoWrite(args map[string]any) string {
@@ -325,7 +326,6 @@ func formatExecuteInput(args map[string]any) string {
 
 func formatDiffBlock(oldText, newText string) string {
 	var b strings.Builder
-	b.WriteString("```diff\n")
 	for _, line := range strings.Split(oldText, "\n") {
 		if oldText == "" {
 			break
@@ -342,17 +342,11 @@ func formatDiffBlock(oldText, newText string) string {
 		b.WriteString(line)
 		b.WriteString("\n")
 	}
-	b.WriteString("```")
-	return b.String()
+	return mdfmt.CodeFence("diff", strings.TrimRight(b.String(), "\n"))
 }
 
 func formatContentBlock(content, path string) string {
-	lang := languageFromPath(path)
-	escaped := strings.ReplaceAll(content, "```", "\\```")
-	if lang == "" {
-		return fmt.Sprintf("```\n%s\n```", escaped)
-	}
-	return fmt.Sprintf("```%s\n%s\n```", lang, escaped)
+	return mdfmt.CodeFence(languageFromPath(path), content)
 }
 
 func languageFromPath(path string) string {

--- a/specstory-cli/pkg/providers/droidcli/markdown_tools.go
+++ b/specstory-cli/pkg/providers/droidcli/markdown_tools.go
@@ -7,6 +7,8 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+
+	"github.com/specstoryai/getspecstory/specstory-cli/pkg/mdfmt"
 )
 
 func formatToolCall(tool *fdToolCall) string {
@@ -86,7 +88,7 @@ func formatToolOutput(tool *fdToolCall) string {
 		label = "Output (error)"
 	}
 	if strings.Contains(content, "\n") {
-		return fmt.Sprintf("%s:\n```text\n%s\n```", label, content)
+		return fmt.Sprintf("%s:\n%s", label, mdfmt.CodeFence("text", content))
 	}
 	return fmt.Sprintf("%s: %s", label, content)
 }
@@ -109,26 +111,24 @@ func formatEditDiffOutput(content string) string {
 		return ""
 	}
 
-	var builder strings.Builder
-	builder.WriteString("```diff\n")
+	var body strings.Builder
 	for _, line := range result.DiffLines {
 		switch line.Type {
 		case "added":
-			builder.WriteString("+")
-			builder.WriteString(line.Content)
-			builder.WriteString("\n")
+			body.WriteString("+")
+			body.WriteString(line.Content)
+			body.WriteString("\n")
 		case "removed":
-			builder.WriteString("-")
-			builder.WriteString(line.Content)
-			builder.WriteString("\n")
+			body.WriteString("-")
+			body.WriteString(line.Content)
+			body.WriteString("\n")
 		case "unchanged":
-			builder.WriteString(" ")
-			builder.WriteString(line.Content)
-			builder.WriteString("\n")
+			body.WriteString(" ")
+			body.WriteString(line.Content)
+			body.WriteString("\n")
 		}
 	}
-	builder.WriteString("```")
-	return builder.String()
+	return mdfmt.CodeFence("diff", strings.TrimRight(body.String(), "\n"))
 }
 
 func decodeInput(raw json.RawMessage) map[string]any {
@@ -358,24 +358,22 @@ func renderSingleEdit(args map[string]any) string {
 }
 
 func formatDiffBlock(oldText string, newText string) string {
-	var builder strings.Builder
-	builder.WriteString("```diff\n")
+	var body strings.Builder
 	if oldText != "" {
 		for _, line := range strings.Split(oldText, "\n") {
-			builder.WriteString("-")
-			builder.WriteString(line)
-			builder.WriteString("\n")
+			body.WriteString("-")
+			body.WriteString(line)
+			body.WriteString("\n")
 		}
 	}
 	if newText != "" {
 		for _, line := range strings.Split(newText, "\n") {
-			builder.WriteString("+")
-			builder.WriteString(line)
-			builder.WriteString("\n")
+			body.WriteString("+")
+			body.WriteString(line)
+			body.WriteString("\n")
 		}
 	}
-	builder.WriteString("```")
-	return builder.String()
+	return mdfmt.CodeFence("diff", strings.TrimRight(body.String(), "\n"))
 }
 
 func renderApplyPatch(args map[string]any) string {
@@ -383,7 +381,7 @@ func renderApplyPatch(args map[string]any) string {
 	if patch == "" {
 		return renderGenericJSON(args)
 	}
-	return fmt.Sprintf("```diff\n%s\n```", strings.TrimSpace(patch))
+	return mdfmt.CodeFence("diff", strings.TrimSpace(patch))
 }
 
 func renderTodoWrite(args map[string]any) string {
@@ -700,12 +698,7 @@ func formatQuotedList(values []string) string {
 }
 
 func formatContentBlock(content string, path string) string {
-	lang := languageFromPath(path)
-	escaped := strings.ReplaceAll(content, "```", "\\```")
-	if lang == "" {
-		return fmt.Sprintf("```\n%s\n```", escaped)
-	}
-	return fmt.Sprintf("```%s\n%s\n```", lang, escaped)
+	return mdfmt.CodeFence(languageFromPath(path), content)
 }
 
 func languageFromPath(path string) string {

--- a/specstory-cli/pkg/providers/geminicli/markdown_tools.go
+++ b/specstory-cli/pkg/providers/geminicli/markdown_tools.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"path/filepath"
 	"strings"
+
+	"github.com/specstoryai/getspecstory/specstory-cli/pkg/mdfmt"
 )
 
 // formatToolAsMarkdown generates formatted markdown for a ToolInfo (input + output)
@@ -123,7 +125,7 @@ func formatReadFileResultFromOutput(tool *ToolInfo) string {
 
 	filePath := inputAsString(tool.Input, "file_path")
 	lang := languageFromPath(filePath)
-	return fmt.Sprintf("```%s\n%s\n```", lang, output)
+	return mdfmt.CodeFence(lang, output)
 }
 
 // formatSearchListResultFromOutput shows raw output without code fence
@@ -152,7 +154,7 @@ func formatDefaultResultFromOutput(output map[string]interface{}) string {
 // formatOutputText wraps multi-line output in code fence, leaves single-line as-is
 func formatOutputText(output string) string {
 	if strings.Contains(output, "\n") {
-		return fmt.Sprintf("```text\n%s\n```", output)
+		return mdfmt.CodeFence("text", output)
 	}
 	return output
 }
@@ -179,9 +181,7 @@ func formatShellBodyFromInput(input map[string]interface{}) string {
 	}
 
 	if command != "" {
-		builder.WriteString("```bash\n")
-		builder.WriteString(command)
-		builder.WriteString("\n```")
+		builder.WriteString(mdfmt.CodeFence("bash", command))
 	}
 
 	return builder.String()
@@ -199,11 +199,7 @@ func formatWriteFileBodyFromInput(input map[string]interface{}) string {
 		fmt.Fprintf(&builder, "Path: `%s`\n\n", path)
 	}
 	if content != "" {
-		builder.WriteString("```")
-		builder.WriteString(languageFromPath(path))
-		builder.WriteString("\n")
-		builder.WriteString(content)
-		builder.WriteString("\n```")
+		builder.WriteString(mdfmt.CodeFence(languageFromPath(path), content))
 	}
 	return builder.String()
 }
@@ -220,9 +216,7 @@ func formatReplaceBodyFromInput(input map[string]interface{}) string {
 		fmt.Fprintf(&builder, "Path: `%s`\n\n", path)
 	}
 	if newString != "" {
-		builder.WriteString("```diff\n")
-		builder.WriteString(truncate(newString, 2000))
-		builder.WriteString("\n```")
+		builder.WriteString(mdfmt.CodeFence("diff", truncate(newString, 2000)))
 	}
 	return builder.String()
 }
@@ -281,7 +275,7 @@ func formatGenericBodyFromInput(input map[string]interface{}) string {
 	if err != nil {
 		return ""
 	}
-	return fmt.Sprintf("```json\n%s\n```", string(bytes))
+	return mdfmt.CodeFence("json", string(bytes))
 }
 
 // inputAsString extracts a string value from tool input

--- a/specstory-cli/pkg/session/markdown.go
+++ b/specstory-cli/pkg/session/markdown.go
@@ -2,10 +2,12 @@ package session
 
 import (
 	"fmt"
+	"html"
 	"sort"
 	"strings"
 	"time"
 
+	"github.com/specstoryai/getspecstory/specstory-cli/pkg/mdfmt"
 	"github.com/specstoryai/getspecstory/specstory-cli/pkg/spi/schema"
 )
 
@@ -206,8 +208,10 @@ func renderToolInfo(tool *ToolInfo) string {
 
 	// Generate summary tag
 	if tool.Summary != nil && *tool.Summary != "" {
-		// Provider provided custom summary content
-		fmt.Fprintf(&markdown, "<summary>%s</summary>\n", *tool.Summary)
+		// Provider provided custom summary content. It sits inside an HTML
+		// <summary> tag, so a literal </summary> or angle bracket in the
+		// summary text would break the disclosure widget — escape it.
+		fmt.Fprintf(&markdown, "<summary>%s</summary>\n", html.EscapeString(*tool.Summary))
 	} else {
 		// Generate default summary
 		fmt.Fprintf(&markdown, "<summary>Tool use: **%s**</summary>\n", tool.Name)
@@ -270,9 +274,9 @@ func renderGenericTool(tool *ToolInfo) string {
 		}
 
 		if content, ok := tool.Output["content"].(string); ok {
-			markdown.WriteString("```\n")
-			markdown.WriteString(content)
-			markdown.WriteString("\n```\n")
+			// Fence is sized so embedded ``` in output can't break out.
+			markdown.WriteString(mdfmt.CodeFence("", content))
+			markdown.WriteString("\n")
 		}
 	}
 


### PR DESCRIPTION
## Problem

Tool output is wrapped in a fenced code block, but several paths write the content into a **fixed 3-backtick** fence without neutralizing fences inside the content. When tool output contains its own ` ``` ` fences — e.g. `cat README.md`, a diff of a markdown file, JSON, help text — and especially when that output is unbalanced (truncated mid-block), the embedded fence closes the wrapper early and the trailing open fence is never closed. Every Markdown renderer then treats **the rest of the document** as one code block.

Observed in the wild: a single `Bash` result that `cat`-ed a README folded ~9,000 lines of the rendered `.md`.

The repo already escapes ` ``` ` in a few spots (`strings.ReplaceAll(content, "```", "\\```")`, e.g. `formatBashTool`/`formatWriteTool`), but:
- it's applied inconsistently — most tool-**output** sinks skip it (claudecode `agent_session.go`, the shared `renderGenericTool` fallback, and the output/diff paths in codex/gemini/droid/deepseek/cursor);
- it only neutralizes runs of **exactly three** backticks (a 4-backtick run still closes the fence);
- it injects a visible `\` artifact into the rendered code.

## Fix

Add `pkg/mdfmt.CodeFence(lang, content)`, which sizes the opening/closing fence to **one backtick longer than the longest backtick run in the content** (minimum 3). This is the CommonMark-recommended way to embed arbitrary content: a fence is closed only by a run of ≥ its own length, so no inner run can break out — and unlike escaping, it leaves no artifact.

Routed the tool-output / file-content / diff / command / JSON sinks through it across **every provider** (claudecode, codex, gemini, droid, deepseek, cursor) and the shared `renderGenericTool` fallback, and replaced the old `ReplaceAll` escape idiom. Also HTML-escaped provider-supplied `<summary>` text so a literal `</summary>` can't break the disclosure widget.

Model/user **prose** is intentionally left untouched — it legitimately contains fenced code blocks, so wrapping or escaping it would be wrong.

## Tests

- `pkg/mdfmt`: unit tests for fence sizing (incl. 4-backtick runs), single-block well-formedness, and no-backslash-artifact.
- `claudecode`: integration test reproducing the real fold (tool output with embedded/unbalanced ` ``` `), asserting a balanced 4-backtick wrapper.
- Updated `cursorcli` tests that asserted the old `\` -escaped output to the new widened-fence behavior.
- `go build ./...`, `go vet ./...`, `go test ./...`, and `golangci-lint run ./...` all clean.