### PR TITLE
feat(monitor): source-tree watch supervisor (copilot-IDE detection build-gated)

### DIFF
--- a/specstory-cli/changelog.md
+++ b/specstory-cli/changelog.md
@@ -1,5 +1,15 @@
 # Specstory CLI Changelog
 
+## [Unreleased]
+
+### 📢 Announcements
+
+- New `specstory monitor <root-dir>` command: discovers every git repo under a root directory, watches the coding agents' session storage (Claude Code, Codex CLI, Cursor CLI) for activity, and supervises per-repo `specstory watch` processes — spawning them on agent activity and stopping them after a configurable idle timeout (`--idle-timeout`, default 5m). Repo discovery depth and exclusions are tunable via `--max-depth` / `--exclude`, and defaults can be set in the new `[monitor]` config section.
+
+### 🔧 CLI Configuration & Commands
+
+- The monitor also includes VS Code Copilot IDE chat-activity detection (stock VS Code, Insiders, VSCodium, and VSCodium Insiders), but it is compiled out of the default build behind the `copilotide_monitor` build tag and is inactive until the `copilotide` provider lands in this tree. Cursor IDE activity detection is deferred because Cursor stores chat activity in SQLite databases, which requires polling machinery rather than path mapping.
+
 ## v2.4.0 2026-07-20
 
 ### ⚙️ Improvements

--- a/specstory-cli/main.go
+++ b/specstory-cli/main.go
@@ -1460,6 +1460,7 @@ func main() {
 	rootCmd = createRootCommand()
 	runCmd = createRunCommand()
 	watchCmd := cmdpkg.CreateWatchCommand(&cloudURL, sessionFlagDefaults)
+	monitorCmd := cmdpkg.CreateMonitorCommand(cfg.MonitorIdleTimeout(), cfg.MonitorMaxDepth(), cfg.MonitorExclude())
 	resumeCmd := cmdpkg.CreateResumeCommand(&cloudURL, sessionFlagDefaults)
 	reindexCmd := cmdpkg.CreateReindexCommand()
 	searchCmd := cmdpkg.CreateSearchCommand(&cloudURL, sessionFlagDefaults)
@@ -1484,6 +1485,7 @@ func main() {
 	// Add the subcommands
 	rootCmd.AddCommand(runCmd)
 	rootCmd.AddCommand(watchCmd)
+	rootCmd.AddCommand(monitorCmd)
 	rootCmd.AddCommand(resumeCmd)
 	rootCmd.AddCommand(reindexCmd)
 	rootCmd.AddCommand(searchCmd)

--- a/specstory-cli/pkg/analytics/events.go
+++ b/specstory-cli/pkg/analytics/events.go
@@ -10,6 +10,7 @@ import (
 const (
 	EventExtensionActivated     = "ext_activated"                // Tracks when `run` command is started
 	EventWatchActivated         = "ext_watch_activated"          // Tracks when `watch` command is started
+	EventMonitorActivated       = "ext_monitor_activated"        // Tracks when `monitor` command is started
 	EventResumeActivated        = "ext_resume_activated"         // Tracks when `resume` command is started
 	EventReindexCompleted       = "ext_reindex_completed"        // Tracks when `reindex` finishes building the restore index
 	EventResumeReconstructed    = "ext_resume_reconstructed"     // Tracks the outcome of a cross-agent session reconstruction (success/unsupported/error)

--- a/specstory-cli/pkg/cmd/monitor.go
+++ b/specstory-cli/pkg/cmd/monitor.go
@@ -1,0 +1,210 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+	"os/signal"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/specstoryai/getspecstory/specstory-cli/pkg/analytics"
+	"github.com/specstoryai/getspecstory/specstory-cli/pkg/log"
+	"github.com/specstoryai/getspecstory/specstory-cli/pkg/monitor"
+	"github.com/specstoryai/getspecstory/specstory-cli/pkg/utils"
+)
+
+// CreateMonitorCommand creates the monitor command. The default values arrive
+// resolved from config (like CreateWatchCommand's parameters) so config-file
+// settings show up as flag defaults; CLI flags still win.
+// Global --console/--log/--debug behave exactly as they do for watch: they are
+// root persistent flags inherited by this command.
+func CreateMonitorCommand(defaultIdleTimeout time.Duration, defaultMaxDepth int, defaultExclude []string) *cobra.Command {
+	monitorCmd := &cobra.Command{
+		Use:     "monitor <root-dir>",
+		Aliases: []string{"m"},
+		Short:   "Supervise 'specstory watch' across all git repos under a directory",
+		Long: `Discover every git repository under <root-dir> and supervise per-repo 'specstory watch' processes.
+
+The monitor watches the coding agents' own session storage (Claude Code, Codex CLI, and Cursor CLI)
+for new activity, maps that activity back to a discovered repository, and starts a 'specstory watch'
+child in that repository. Children idle past the timeout are stopped and respawned on new activity.
+
+Each child follows your own SpecStory configuration (cloud sync, redaction, logging, ...).`,
+		Example: `
+# Supervise all git repos under ~/src
+specstory monitor ~/src
+
+# Stop idle watchers sooner and search deeper
+specstory monitor ~/src --idle-timeout 2m --max-depth 6
+
+# Skip directories during repo discovery
+specstory monitor ~/src --exclude "archive/*" --exclude scratch`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			slog.Info("Running in monitor mode")
+
+			// Read flags from the command
+			idleTimeoutStr, _ := cmd.Flags().GetString("idle-timeout")
+			maxDepth, _ := cmd.Flags().GetInt("max-depth")
+			excludes, _ := cmd.Flags().GetStringArray("exclude")
+			storageRootOverrides, _ := cmd.Flags().GetStringArray("storage-root")
+
+			idleTimeout, err := time.ParseDuration(idleTimeoutStr)
+			if err != nil || idleTimeout <= 0 {
+				return utils.ValidationError{Message: fmt.Sprintf("invalid --idle-timeout %q: must be a positive Go duration (e.g. \"5m\")", idleTimeoutStr)}
+			}
+
+			rootDir, err := filepath.Abs(utils.ExpandTilde(args[0]))
+			if err != nil {
+				return utils.ValidationError{Message: fmt.Sprintf("invalid root directory %q: %v", args[0], err)}
+			}
+			info, err := os.Stat(rootDir)
+			if err != nil || !info.IsDir() {
+				return utils.ValidationError{Message: fmt.Sprintf("root directory %q does not exist or is not a directory", rootDir)}
+			}
+
+			roots, err := monitor.DefaultStorageRoots()
+			if err != nil {
+				return fmt.Errorf("failed to determine agent storage roots: %w", err)
+			}
+			if err := applyStorageRootOverrides(&roots, storageRootOverrides); err != nil {
+				return err
+			}
+
+			// Repo discovery is startup-only: repos created under the root
+			// after the monitor starts are picked up on the next monitor run.
+			repos, err := monitor.DiscoverRepos(rootDir, maxDepth, excludes)
+			if err != nil {
+				return fmt.Errorf("failed to discover git repos under %s: %w", rootDir, err)
+			}
+			slog.Info("Monitor: discovered git repos", "root", rootDir, "count", len(repos), "repos", repos)
+			if len(repos) == 0 {
+				return utils.ValidationError{Message: fmt.Sprintf("no git repos found under %s (searched %d levels deep)", rootDir, maxDepth)}
+			}
+
+			analytics.TrackEvent(analytics.EventMonitorActivated, analytics.Properties{
+				"repo_count":   len(repos),
+				"idle_timeout": idleTimeout.String(),
+			})
+
+			resolver := monitor.NewResolver(repos, roots)
+			supervisor := monitor.NewSupervisor(idleTimeout)
+
+			// Graceful cancellation (Ctrl+C / SIGTERM), mirroring watch: the
+			// context stops the storage-root watchers and the reap loop, then
+			// Shutdown below terminates every child before we return.
+			ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+			defer cancel()
+
+			// The monitor captures activity forward from launch: pre-existing
+			// storage entries are deliberately NOT scanned or spawned for.
+			// Anything already there is historical — possibly minutes,
+			// possibly months old — and spawning watchers for history would
+			// start children for repos with no live agent, only for the reaper
+			// to churn through them. New events tell us something is live NOW.
+			onActivity := func(eventPath string) {
+				if repo, ok := resolver.Resolve(eventPath); ok {
+					supervisor.NotifyActivity(repo)
+				}
+			}
+			started := 0
+			for provider, storageRoot := range map[string]string{
+				"claude": roots.Claude,
+				"codex":  roots.Codex,
+				"cursor": roots.Cursor,
+			} {
+				if _, statErr := os.Stat(storageRoot); statErr != nil {
+					slog.Info("Monitor: skipping missing storage root", "provider", provider, "path", storageRoot)
+					continue
+				}
+				started++
+				go func(provider, storageRoot string) {
+					slog.Info("Monitor: watching storage root", "provider", provider, "path", storageRoot)
+					if watchErr := monitor.WatchRootForNewEntries(ctx, storageRoot, onActivity); watchErr != nil {
+						slog.Error("Monitor: storage root watcher failed", "provider", provider, "path", storageRoot, "error", watchErr)
+					}
+				}(provider, storageRoot)
+			}
+			// VS Code Copilot chat storage gets dedicated selective watchers
+			// (one per installed VS Code variant) rather than the generic
+			// recursive root watcher above, because workspaceStorage can hold
+			// thousands of workspace directories and would exhaust file
+			// descriptors. That code depends on the copilotide provider, which
+			// is not yet present in this tree, so it is compiled only under the
+			// copilotide_monitor build tag; the default build's stub starts none.
+			started += startCopilotWatchers(ctx, roots, resolver, supervisor)
+			if started == 0 {
+				return utils.ValidationError{Message: "no agent storage roots exist to watch (looked for Claude Code, Codex CLI, and Cursor CLI session storage)"}
+			}
+
+			go supervisor.Run(ctx)
+
+			if !log.IsSilent() {
+				fmt.Println()
+				repoWord := "repos"
+				if len(repos) == 1 {
+					repoWord = "repo"
+				}
+				fmt.Printf("🔭 Monitoring %d git %s under %s\n", len(repos), repoWord, rootDir)
+				fmt.Println("   Watch processes start on agent activity and stop after", idleTimeout, "idle")
+				fmt.Println("   Press Ctrl+C to stop monitoring")
+				fmt.Println()
+			}
+
+			<-ctx.Done()
+			slog.Info("Monitor: shutting down")
+			supervisor.Shutdown()
+			return nil
+		},
+	}
+
+	// Monitor-specific flags. --idle-timeout is a string (not a cobra Duration)
+	// so config values pass through verbatim and the error message is ours.
+	monitorCmd.Flags().String("idle-timeout", defaultIdleTimeout.String(), "stop a repo's watch process after this much inactivity (Go duration, e.g. \"5m\")")
+	monitorCmd.Flags().Int("max-depth", defaultMaxDepth, "how many directory levels below <root-dir> to search for git repos")
+	monitorCmd.Flags().StringArray("exclude", defaultExclude, "path glob (relative to <root-dir>) to skip during repo discovery (repeatable)")
+	monitorCmd.Flags().StringArray("storage-root", nil, "TEST ONLY: override an agent storage root as provider:path (providers: claude, codex, cursor; repeatable)")
+	_ = monitorCmd.Flags().MarkHidden("storage-root") // Hidden test-only flag
+
+	return monitorCmd
+}
+
+// applyStorageRootOverrides applies hidden --storage-root provider:path
+// overrides. This exists solely so tests (and the release smoke test) can
+// point a provider's storage root at a fixture directory instead of the real
+// ~ paths; it is not part of the public interface.
+func applyStorageRootOverrides(roots *monitor.StorageRoots, overrides []string) error {
+	for _, override := range overrides {
+		provider, path, found := strings.Cut(override, ":")
+		if !found || path == "" {
+			return utils.ValidationError{Message: fmt.Sprintf("invalid --storage-root %q: expected provider:path", override)}
+		}
+		abs, err := filepath.Abs(utils.ExpandTilde(path))
+		if err != nil {
+			return utils.ValidationError{Message: fmt.Sprintf("invalid --storage-root path %q: %v", path, err)}
+		}
+		switch provider {
+		case "claude":
+			roots.Claude = abs
+		case "codex":
+			roots.Codex = abs
+		case "cursor":
+			roots.Cursor = abs
+		default:
+			// copilotStorageRootOverride handles the copilotide provider, but
+			// only in the copilotide_monitor build; the default build's stub
+			// returns false, so an unknown provider falls through to the error.
+			if copilotStorageRootOverride(roots, provider, abs) {
+				continue
+			}
+			return utils.ValidationError{Message: fmt.Sprintf("invalid --storage-root provider %q: must be claude, codex, or cursor", provider)}
+		}
+	}
+	return nil
+}

--- a/specstory-cli/pkg/cmd/monitor_copilotide.go
+++ b/specstory-cli/pkg/cmd/monitor_copilotide.go
@@ -1,0 +1,66 @@
+//go:build copilotide_monitor
+
+package cmd
+
+import (
+	"context"
+	"log/slog"
+	"os"
+
+	"github.com/specstoryai/getspecstory/specstory-cli/pkg/monitor"
+	"github.com/specstoryai/getspecstory/specstory-cli/pkg/providers/copilotide"
+)
+
+// startCopilotWatchers launches a dedicated selective watcher for each installed
+// VS Code Copilot IDE variant's workspaceStorage and returns how many it started.
+//
+// VS Code Copilot chat storage gets a dedicated selective watcher
+// (monitor.WatchCopilotWorkspaceStorage): workspaceStorage can hold thousands of
+// workspace directories, so the generic recursive root watcher would exhaust
+// file descriptors. The watcher resolves events to repos itself, so activity
+// feeds the supervisor directly. Absent variants are common (most machines run
+// at most one VS Code distribution), hence the quiet Debug-level skip.
+//
+// This is the copilotide_monitor build's implementation; it depends on the
+// copilotide provider package, which is not yet present in this tree, so it is
+// gated behind the copilotide_monitor tag. The default build uses the stub in
+// monitor_stub.go, which starts nothing.
+func startCopilotWatchers(ctx context.Context, roots monitor.StorageRoots, resolver *monitor.Resolver, supervisor *monitor.Supervisor) int {
+	started := 0
+	for _, variant := range copilotide.Variants() {
+		storageRoot := roots.CopilotIDE[variant.ID]
+		if storageRoot == "" {
+			slog.Debug("Monitor: skipping absent Copilot IDE variant", "variant", variant.AppName)
+			continue
+		}
+		if _, statErr := os.Stat(storageRoot); statErr != nil {
+			slog.Debug("Monitor: skipping missing Copilot IDE workspace storage", "variant", variant.AppName, "path", storageRoot)
+			continue
+		}
+		started++
+		go func(appName, storageRoot string) {
+			slog.Info("Monitor: watching Copilot IDE workspace storage", "variant", appName, "path", storageRoot)
+			if watchErr := monitor.WatchCopilotWorkspaceStorage(ctx, storageRoot, resolver, supervisor.NotifyActivity); watchErr != nil {
+				slog.Error("Monitor: Copilot IDE storage watcher failed", "variant", appName, "path", storageRoot, "error", watchErr)
+			}
+		}(variant.AppName, storageRoot)
+	}
+	return started
+}
+
+// copilotStorageRootOverride handles a hidden --storage-root override targeting
+// the copilotide provider. It returns true when it handled the provider, false
+// otherwise (so the caller falls through to its unknown-provider error). The
+// override targets the stock "Code" variant only; that is enough for fixture
+// testing, and per-variant overrides would complicate the provider:path syntax
+// for no test benefit.
+func copilotStorageRootOverride(roots *monitor.StorageRoots, provider, abs string) bool {
+	if provider != "copilotide" {
+		return false
+	}
+	if roots.CopilotIDE == nil {
+		roots.CopilotIDE = make(map[string]string)
+	}
+	roots.CopilotIDE[copilotide.VSCode.ID] = abs
+	return true
+}

--- a/specstory-cli/pkg/cmd/monitor_stub.go
+++ b/specstory-cli/pkg/cmd/monitor_stub.go
@@ -1,0 +1,25 @@
+//go:build !copilotide_monitor
+
+package cmd
+
+import (
+	"context"
+
+	"github.com/specstoryai/getspecstory/specstory-cli/pkg/monitor"
+)
+
+// startCopilotWatchers starts no watchers in the default build. VS Code Copilot
+// IDE detection depends on the copilotide provider package, which is not yet
+// present in this tree, so it is gated behind the copilotide_monitor build tag.
+// Building with that tag swaps in the real implementation in monitor_copilotide.go.
+func startCopilotWatchers(_ context.Context, _ monitor.StorageRoots, _ *monitor.Resolver, _ *monitor.Supervisor) int {
+	return 0
+}
+
+// copilotStorageRootOverride handles no providers in the default build, so a
+// --storage-root copilotide:... override falls through to the caller's
+// unknown-provider error. Gated behind copilotide_monitor; see
+// monitor_copilotide.go for the real implementation.
+func copilotStorageRootOverride(_ *monitor.StorageRoots, _, _ string) bool {
+	return false
+}

--- a/specstory-cli/pkg/config/config.go
+++ b/specstory-cli/pkg/config/config.go
@@ -14,6 +14,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/BurntSushi/toml"
 )
@@ -108,6 +109,27 @@ const defaultConfigTemplate = `# SpecStory CLI Configuration
 # keys, and other credentials for many providers.
 # enabled = false # equivalent to --no-redact-secrets
 
+[monitor]
+# Settings for 'specstory monitor <root-dir>', which discovers every git repo
+# under a root directory and starts/stops 'specstory watch' children as coding
+# agent activity comes and goes.
+
+# Stop a repo's watch child after this much inactivity (Go duration string).
+# Default: "5m"
+# idle_timeout = "10m" # equivalent to --idle-timeout "10m"
+
+# How many directory levels below the root dir to search for git repos (root = 0).
+# Default: 4
+# max_depth = 6 # equivalent to --max-depth 6
+
+# Path globs (relative to the root dir) to skip during repo discovery.
+# node_modules, vendor, and .git are always skipped.
+# exclude = ["archive/*", "scratch"] # equivalent to repeated --exclude flags
+
+# Reserved for future use: default root directories to monitor when none is
+# given on the command line. The CLI currently requires the root-dir argument.
+# root_dirs = ["~/src"]
+
 [providers]
 # Agent execution commands by provider (used by specstory run)
 # Pass custom flags (e.g. claude_cmd = "claude --allow-dangerously-skip-permissions")
@@ -144,6 +166,7 @@ type Config struct {
 	Analytics    AnalyticsConfig    `toml:"analytics"`
 	Telemetry    TelemetryConfig    `toml:"telemetry"`
 	Redaction    RedactionConfig    `toml:"redaction"`
+	Monitor      MonitorConfig      `toml:"monitor"`
 	Providers    ProvidersConfig    `toml:"providers"`
 	Resume       ResumeConfig       `toml:"resume"`
 	Skills       SkillsConfig       `toml:"skills"`
@@ -166,6 +189,22 @@ type SkillsConfig struct {
 	ViewMode string `toml:"view_mode"`
 	// DefaultLocation is the last-used install location: "global" or "project".
 	DefaultLocation string `toml:"default_location"`
+}
+
+// MonitorConfig holds settings for the `specstory monitor` supervisor command.
+type MonitorConfig struct {
+	// RootDirs is reserved for future use (defaulting the monitor root when no
+	// argument is given); the CLI currently requires the root-dir argument.
+	RootDirs []string `toml:"root_dirs"`
+	// IdleTimeout is how long a repo may be inactive before its watch child is
+	// stopped, as a Go duration string (e.g. "5m"). Defaults to 5m.
+	IdleTimeout string `toml:"idle_timeout"`
+	// MaxDepth limits how many directory levels below the root dir are
+	// searched for git repos (root = 0). Defaults to 4 when not set.
+	MaxDepth *int `toml:"max_depth"`
+	// Exclude is a list of path globs (relative to the root dir) skipped
+	// during repo discovery.
+	Exclude []string `toml:"exclude"`
 }
 
 // RedactionConfig holds secret redaction settings for markdown output and
@@ -942,6 +981,51 @@ func (c *Config) IsRedactionEnabled() bool {
 		return *c.Redaction.Enabled
 	}
 	return true // default: redaction on
+}
+
+// Monitor defaults live here (not in pkg/monitor) so the config file, the CLI
+// flag defaults, and the help text all resolve from one place.
+const (
+	// defaultMonitorIdleTimeout is how long a repo may be inactive before its
+	// watch child is reaped when idle_timeout is not configured.
+	defaultMonitorIdleTimeout = 5 * time.Minute
+	// defaultMonitorMaxDepth is the repo discovery depth limit when max_depth
+	// is not configured.
+	defaultMonitorMaxDepth = 4
+)
+
+// MonitorIdleTimeout returns how long a monitored repo may be inactive before
+// its watch child is stopped. Defaults to 5m; unparseable or non-positive
+// configured values fall back to the default (with a warning) rather than
+// failing startup, because the monitor is a long-running supervisor and a
+// typo'd config shouldn't keep it from running at all.
+func (c *Config) MonitorIdleTimeout() time.Duration {
+	if c.Monitor.IdleTimeout == "" {
+		return defaultMonitorIdleTimeout
+	}
+	d, err := time.ParseDuration(c.Monitor.IdleTimeout)
+	if err != nil || d <= 0 {
+		slog.Warn("Invalid [monitor] idle_timeout in config; using default",
+			"value", c.Monitor.IdleTimeout,
+			"default", defaultMonitorIdleTimeout,
+			"error", err)
+		return defaultMonitorIdleTimeout
+	}
+	return d
+}
+
+// MonitorMaxDepth returns the repo discovery depth limit (root dir = 0).
+// Defaults to 4 if not explicitly set.
+func (c *Config) MonitorMaxDepth() int {
+	if c.Monitor.MaxDepth != nil {
+		return *c.Monitor.MaxDepth
+	}
+	return defaultMonitorMaxDepth
+}
+
+// MonitorExclude returns the path globs excluded from repo discovery.
+func (c *Config) MonitorExclude() []string {
+	return c.Monitor.Exclude
 }
 
 // GetProviderCmd returns the custom execution command for a provider, or empty

--- a/specstory-cli/pkg/monitor/activity.go
+++ b/specstory-cli/pkg/monitor/activity.go
@@ -1,0 +1,246 @@
+package monitor
+
+import (
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/specstoryai/getspecstory/specstory-cli/pkg/providers/claudecode"
+	"github.com/specstoryai/getspecstory/specstory-cli/pkg/providers/codexcli"
+	"github.com/specstoryai/getspecstory/specstory-cli/pkg/providers/cursorcli"
+)
+
+// StorageRoots holds the agent-side session storage directories the monitor
+// watches. Injectable (rather than hardcoded ~ paths) so tests can point each
+// root at a t.TempDir() fixture and so the hidden --storage-root flag can
+// redirect them for smoke testing.
+type StorageRoots struct {
+	Claude string // ~/.claude/projects
+	Codex  string // ~/.codex/sessions (honors CODEX_HOME)
+	Cursor string // ~/.cursor/chats
+	// CopilotIDE maps a VS Code variant ID (copilotide.Variant.ID, e.g.
+	// "copilotide" for stock VS Code) to that variant's workspaceStorage
+	// directory. Per-variant because each VS Code distribution keeps its own
+	// storage tree; variants absent from this machine have no entry.
+	CopilotIDE map[string]string
+}
+
+// DefaultStorageRoots returns the real storage roots the agents write to.
+// Paths are returned whether or not they exist; the monitor command skips
+// missing ones at startup.
+func DefaultStorageRoots() (StorageRoots, error) {
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return StorageRoots{}, err
+	}
+
+	// Codex honors CODEX_HOME; reuse the provider's own root resolution so the
+	// monitor watches exactly where the codexcli provider reads from.
+	codexRoot, err := codexcli.SessionsRoot()
+	if err != nil {
+		return StorageRoots{}, err
+	}
+
+	cursorRoot, err := cursorcli.GetCursorChatsDir()
+	if err != nil {
+		return StorageRoots{}, err
+	}
+
+	// Copilot chat storage is per VS Code distribution. copilotStorageRoots
+	// resolves the per-variant workspaceStorage directories, but only when the
+	// build is compiled with the copilotide_monitor tag (which pulls in the
+	// copilotide provider); the default build returns nil here and the monitor
+	// simply watches no Copilot IDE storage.
+	copilotRoots := copilotStorageRoots()
+
+	return StorageRoots{
+		// claudecode only exports an existence-checking accessor for this path
+		// (GetClaudeCodeProjectsDir), but we need the path even when it does
+		// not exist yet, so build it the same way that accessor does.
+		Claude:     filepath.Join(homeDir, ".claude", "projects"),
+		Codex:      codexRoot,
+		Cursor:     cursorRoot,
+		CopilotIDE: copilotRoots,
+	}, nil
+}
+
+// repoEntry caches the per-repo lookup keys used by each provider's resolver.
+type repoEntry struct {
+	// path is the repo root exactly as discovered (what the supervisor spawns
+	// watch children in).
+	path string
+	// canonical is the symlink-resolved path used for cwd prefix comparisons,
+	// because agents may record either form (macOS /tmp vs /private/tmp etc.).
+	canonical string
+	// claudeEncoded is Claude Code's project-directory name for this repo.
+	claudeEncoded string
+}
+
+// Resolver maps a storage-root filesystem event to the discovered repository
+// the activity belongs to.
+type Resolver struct {
+	roots StorageRoots
+	// repos is sorted by descending canonical-path length so prefix scans
+	// naturally implement longest-prefix matching (a session cwd may be a
+	// subdirectory of one repo that is itself inside another discovered repo).
+	repos []repoEntry
+	// cursorHashToRepo inverts Cursor's one-way md5(project path) naming by
+	// hashing every discovered repo up front.
+	cursorHashToRepo map[string]string
+}
+
+// NewResolver builds a Resolver for the given discovered repo roots and
+// storage roots. All per-repo derived keys (Claude encoding, Cursor hash,
+// canonical path) are computed once here rather than per event.
+func NewResolver(repos []string, roots StorageRoots) *Resolver {
+	r := &Resolver{
+		roots:            roots,
+		cursorHashToRepo: make(map[string]string, len(repos)),
+	}
+
+	for _, repo := range repos {
+		repo = filepath.Clean(repo)
+
+		// Fall back to the raw path when symlink resolution fails (repo
+		// deleted mid-run); comparisons then just use the discovered form.
+		canonical, err := filepath.EvalSymlinks(repo)
+		if err != nil {
+			canonical = repo
+		}
+
+		r.repos = append(r.repos, repoEntry{
+			path:          repo,
+			canonical:     canonical,
+			claudeEncoded: claudecode.EncodeProjectDirName(repo),
+		})
+
+		if hash := cursorcli.ProjectHash(repo); hash != "" {
+			r.cursorHashToRepo[hash] = repo
+		}
+	}
+
+	sort.Slice(r.repos, func(i, j int) bool {
+		return len(r.repos[i].canonical) > len(r.repos[j].canonical)
+	})
+
+	return r
+}
+
+// Resolve maps a filesystem event path from one of the storage roots to the
+// discovered repo the activity belongs to. Returns ok=false when the event is
+// under no known root, belongs to no discovered repo, or (for Codex) the
+// session metadata isn't readable yet — Codex creates the .jsonl before
+// writing its session_meta line, and the follow-up Write event retries.
+//
+// VS Code Copilot IDE events do not flow through here: workspaceStorage holds
+// thousands of workspace directories, so Copilot uses a dedicated selective
+// watcher (WatchCopilotWorkspaceStorage) that pre-maps the handful of
+// repo-relevant chatSessions directories instead of watching everything.
+//
+// Cursor IDE (pkg/providers/cursoride) has no resolver family here on
+// purpose: its chat activity lands in SQLite databases — every conversation
+// is a key-value row in the single global globalStorage/state.vscdb, with
+// per-workspace state.vscdb files mapping composer IDs to workspaces — so
+// attributing new activity to a project requires opening and polling those
+// databases, not the cheap event-path mapping used below. Deferred until
+// there is demand for it.
+func (r *Resolver) Resolve(eventPath string) (string, bool) {
+	if rel, ok := pathUnder(r.roots.Claude, eventPath); ok {
+		return r.resolveClaude(rel)
+	}
+	if _, ok := pathUnder(r.roots.Codex, eventPath); ok {
+		return r.resolveCodex(eventPath)
+	}
+	if rel, ok := pathUnder(r.roots.Cursor, eventPath); ok {
+		return r.resolveCursor(rel)
+	}
+	return "", false
+}
+
+// resolveClaude maps a path relative to the Claude projects root to a repo.
+// The first component is Claude Code's encoded project directory name. The
+// encoding is lossy and one-way, so instead of decoding we compare against the
+// pre-encoded names of every discovered repo: an exact match is a session in
+// the repo root, and an "<encoded>-" prefix match is a session whose cwd was a
+// subdirectory of the repo (subdir separators encode to dashes). repos is
+// length-sorted so the first hit is the longest — i.e. most specific — match.
+func (r *Resolver) resolveClaude(rel string) (string, bool) {
+	entryName := firstComponent(rel)
+	for _, repo := range r.repos {
+		if entryName == repo.claudeEncoded || strings.HasPrefix(entryName, repo.claudeEncoded+"-") {
+			return repo.path, true
+		}
+	}
+	return "", false
+}
+
+// resolveCodex maps a Codex session file event to a repo by reading the cwd
+// recorded in the session's metadata header, then longest-prefix matching it
+// against the discovered repos.
+func (r *Resolver) resolveCodex(eventPath string) (string, bool) {
+	// Only session .jsonl files carry metadata; directory-creation events for
+	// the YYYY/MM/DD chain (and any stray files) are not activity by themselves.
+	if !strings.HasSuffix(eventPath, ".jsonl") {
+		return "", false
+	}
+	cwd, err := codexcli.SessionOriginCwd(eventPath)
+	if err != nil || cwd == "" {
+		return "", false
+	}
+	return r.repoContaining(cwd)
+}
+
+// resolveCursor maps a path relative to the Cursor chats root to a repo. The
+// first component is md5(project path); the hash is one-way, so lookup uses
+// the table of pre-hashed discovered repos.
+func (r *Resolver) resolveCursor(rel string) (string, bool) {
+	repo, ok := r.cursorHashToRepo[firstComponent(rel)]
+	return repo, ok
+}
+
+// repoContaining returns the discovered repo whose tree contains p, preferring
+// the longest (most deeply nested) match. p may be the repo root itself or any
+// subdirectory of it — agents record the session cwd, which is often a subdir.
+func (r *Resolver) repoContaining(p string) (string, bool) {
+	candidate := filepath.Clean(p)
+	// Compare in canonical (symlink-resolved) space when possible so a cwd
+	// recorded through a symlinked path still matches the discovered repo.
+	if resolved, err := filepath.EvalSymlinks(candidate); err == nil {
+		candidate = resolved
+	}
+
+	for _, repo := range r.repos {
+		if candidate == repo.canonical || strings.HasPrefix(candidate, repo.canonical+string(filepath.Separator)) {
+			return repo.path, true
+		}
+		// Belt and suspenders: also accept the raw discovered form, in case
+		// canonicalization diverged between discovery time and event time.
+		if candidate == repo.path || strings.HasPrefix(candidate, repo.path+string(filepath.Separator)) {
+			return repo.path, true
+		}
+	}
+	return "", false
+}
+
+// pathUnder reports whether p is strictly inside root, returning the relative
+// remainder. The root itself is not "under" (an event for the root directory
+// carries no entry name to resolve).
+func pathUnder(root, p string) (string, bool) {
+	if root == "" {
+		return "", false
+	}
+	prefix := filepath.Clean(root) + string(filepath.Separator)
+	if !strings.HasPrefix(p, prefix) {
+		return "", false
+	}
+	return p[len(prefix):], true
+}
+
+// firstComponent returns the first path component of a relative path.
+func firstComponent(rel string) string {
+	if i := strings.IndexByte(rel, filepath.Separator); i >= 0 {
+		return rel[:i]
+	}
+	return rel
+}

--- a/specstory-cli/pkg/monitor/activity_copilotide.go
+++ b/specstory-cli/pkg/monitor/activity_copilotide.go
@@ -1,0 +1,27 @@
+//go:build copilotide_monitor
+
+package monitor
+
+import (
+	"github.com/specstoryai/getspecstory/specstory-cli/pkg/providers/copilotide"
+)
+
+// copilotStorageRoots returns the workspaceStorage directory for each installed
+// VS Code Copilot IDE variant, keyed by variant ID (copilotide.Variant.ID).
+// Only variants whose workspaceStorage actually exists get an entry
+// (GetWorkspaceStoragePath returns "" otherwise); the monitor command skips
+// absent variants.
+//
+// This is the copilotide_monitor build's implementation: it depends on the
+// copilotide provider package, which is not yet present in this tree, so the
+// whole file is gated behind the copilotide_monitor tag. The default build uses
+// the stub in activity_stub.go, which returns nil.
+func copilotStorageRoots() map[string]string {
+	copilotRoots := make(map[string]string)
+	for _, variant := range copilotide.Variants() {
+		if p := copilotide.GetWorkspaceStoragePath(variant.DataDirName); p != "" {
+			copilotRoots[variant.ID] = p
+		}
+	}
+	return copilotRoots
+}

--- a/specstory-cli/pkg/monitor/activity_stub.go
+++ b/specstory-cli/pkg/monitor/activity_stub.go
@@ -1,0 +1,10 @@
+//go:build !copilotide_monitor
+
+package monitor
+
+// copilotStorageRoots returns no Copilot IDE storage roots in the default build.
+// VS Code Copilot IDE detection depends on the copilotide provider package,
+// which is not yet present in this tree, so it is gated behind the
+// copilotide_monitor build tag. Building with that tag swaps in the real
+// implementation in activity_copilotide.go.
+func copilotStorageRoots() map[string]string { return nil }

--- a/specstory-cli/pkg/monitor/activity_test.go
+++ b/specstory-cli/pkg/monitor/activity_test.go
@@ -1,0 +1,220 @@
+package monitor
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/specstoryai/getspecstory/specstory-cli/pkg/providers/claudecode"
+	"github.com/specstoryai/getspecstory/specstory-cli/pkg/providers/cursorcli"
+)
+
+// activityFixture builds a full resolver fixture: discovered repos (with
+// subdirectories) plus injectable storage roots, all under t.TempDir().
+type activityFixture struct {
+	roots StorageRoots
+	// repo1 and repo2 are the discovered repos; repo2 lives nested one level
+	// down and repo2Sub is a subdirectory inside it (session cwds are often
+	// subdirectories of the repo).
+	repo1, repo1Sub, repo2, repo2Sub string
+}
+
+func newActivityFixture(t *testing.T) *activityFixture {
+	t.Helper()
+	base := t.TempDir()
+	f := &activityFixture{
+		repo1: filepath.Join(base, "repo1"),
+		repo2: filepath.Join(base, "nested", "repo2"),
+		roots: StorageRoots{
+			Claude: filepath.Join(base, "storage", "claude", "projects"),
+			Codex:  filepath.Join(base, "storage", "codex", "sessions"),
+			Cursor: filepath.Join(base, "storage", "cursor", "chats"),
+			CopilotIDE: map[string]string{
+				"copilotide": filepath.Join(base, "storage", "copilot", "workspaceStorage"),
+			},
+		},
+	}
+	f.repo1Sub = filepath.Join(f.repo1, "pkg", "deep")
+	f.repo2Sub = filepath.Join(f.repo2, "sub")
+	for _, dir := range []string{f.repo1Sub, f.repo2Sub, f.roots.Claude, f.roots.Codex, f.roots.Cursor, f.roots.CopilotIDE["copilotide"]} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatalf("failed to create fixture dir %s: %v", dir, err)
+		}
+	}
+	return f
+}
+
+func (f *activityFixture) repos() []string {
+	return []string{f.repo1, f.repo2}
+}
+
+// writeCodexSession writes a minimal real-format Codex session file (the
+// session_meta first line is all the resolver reads) and returns its path.
+func writeCodexSession(t *testing.T, codexRoot, name, cwd string) string {
+	t.Helper()
+	dateDir := filepath.Join(codexRoot, "2026", "07", "15")
+	if err := os.MkdirAll(dateDir, 0o755); err != nil {
+		t.Fatalf("failed to create codex date dir: %v", err)
+	}
+	p := filepath.Join(dateDir, name)
+	line := fmt.Sprintf(`{"type":"session_meta","timestamp":"2026-07-15T12:00:00.000Z","payload":{"id":"0198c5c1-aaaa-bbbb-cccc-000000000001","timestamp":"2026-07-15T12:00:00.000Z","cwd":%q}}`+"\n", cwd)
+	if err := os.WriteFile(p, []byte(line), 0o644); err != nil {
+		t.Fatalf("failed to write codex session file: %v", err)
+	}
+	return p
+}
+
+func TestResolver_Resolve(t *testing.T) {
+	f := newActivityFixture(t)
+	r := NewResolver(f.repos(), f.roots)
+
+	// Fixture names are built with the providers' REAL encoding/hash functions
+	// so the resolver is tested against exactly what the agents produce.
+	encRepo1 := claudecode.EncodeProjectDirName(f.repo1)
+	encRepo1Sub := claudecode.EncodeProjectDirName(f.repo1Sub)
+	hashRepo2 := cursorcli.ProjectHash(f.repo2)
+
+	codexInRepo2Sub := writeCodexSession(t, f.roots.Codex, "rollout-repo2sub.jsonl", f.repo2Sub)
+	codexOutside := writeCodexSession(t, f.roots.Codex, "rollout-outside.jsonl", t.TempDir())
+	codexEmpty := filepath.Join(f.roots.Codex, "2026", "07", "15", "rollout-empty.jsonl")
+	if err := os.WriteFile(codexEmpty, nil, 0o644); err != nil {
+		t.Fatalf("failed to write empty codex file: %v", err)
+	}
+
+	tests := []struct {
+		name      string
+		eventPath string
+		wantRepo  string
+		wantOK    bool
+	}{
+		{
+			name:      "claude project dir created for repo root",
+			eventPath: filepath.Join(f.roots.Claude, encRepo1),
+			wantRepo:  f.repo1,
+			wantOK:    true,
+		},
+		{
+			name:      "claude jsonl inside project dir",
+			eventPath: filepath.Join(f.roots.Claude, encRepo1, "0198c5c1-dead-beef.jsonl"),
+			wantRepo:  f.repo1,
+			wantOK:    true,
+		},
+		{
+			name:      "claude session cwd in repo subdirectory",
+			eventPath: filepath.Join(f.roots.Claude, encRepo1Sub, "session.jsonl"),
+			wantRepo:  f.repo1,
+			wantOK:    true,
+		},
+		{
+			name:      "claude unknown project",
+			eventPath: filepath.Join(f.roots.Claude, "-Users-somebody-else-project"),
+			wantOK:    false,
+		},
+		{
+			name:      "codex session cwd in repo subdirectory",
+			eventPath: codexInRepo2Sub,
+			wantRepo:  f.repo2,
+			wantOK:    true,
+		},
+		{
+			name:      "codex session cwd outside all repos",
+			eventPath: codexOutside,
+			wantOK:    false,
+		},
+		{
+			name: "codex file with no metadata yet",
+			// Codex creates the .jsonl before writing session_meta; the Create
+			// event must resolve to nothing (a later Write retries).
+			eventPath: codexEmpty,
+			wantOK:    false,
+		},
+		{
+			name:      "codex non-jsonl entry (new date directory)",
+			eventPath: filepath.Join(f.roots.Codex, "2026", "07", "16"),
+			wantOK:    false,
+		},
+		{
+			name:      "cursor new session dir under known hash",
+			eventPath: filepath.Join(f.roots.Cursor, hashRepo2, "0198c5c1-1111-2222-3333-444444444444"),
+			wantRepo:  f.repo2,
+			wantOK:    true,
+		},
+		{
+			name:      "cursor unknown hash",
+			eventPath: filepath.Join(f.roots.Cursor, "00000000000000000000000000000000", "session"),
+			wantOK:    false,
+		},
+		{
+			name:      "event outside every storage root",
+			eventPath: filepath.Join(f.repo1, "README.md"),
+			wantOK:    false,
+		},
+		{
+			name:      "storage root itself resolves to nothing",
+			eventPath: f.roots.Claude,
+			wantOK:    false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			repo, ok := r.Resolve(tt.eventPath)
+			if ok != tt.wantOK {
+				t.Fatalf("Resolve(%q) ok = %v, want %v (repo=%q)", tt.eventPath, ok, tt.wantOK, repo)
+			}
+			if ok && repo != tt.wantRepo {
+				t.Errorf("Resolve(%q) = %q, want %q", tt.eventPath, repo, tt.wantRepo)
+			}
+		})
+	}
+}
+
+// TestResolver_LongestPrefixMapping pins the longest-prefix rule: when one
+// discovered repo contains another, a session cwd inside the inner repo maps
+// to the inner repo, not the enclosing one.
+func TestResolver_LongestPrefixMapping(t *testing.T) {
+	f := newActivityFixture(t)
+	outer := filepath.Dir(f.repo2) // .../nested contains .../nested/repo2
+	r := NewResolver([]string{outer, f.repo2}, f.roots)
+
+	tests := []struct {
+		name string
+		cwd  string
+		want string
+	}{
+		{name: "cwd inside inner repo maps to inner", cwd: f.repo2Sub, want: f.repo2},
+		{name: "cwd at inner repo root maps to inner", cwd: f.repo2, want: f.repo2},
+		{name: "cwd in outer but not inner maps to outer", cwd: outer, want: outer},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := writeCodexSession(t, f.roots.Codex, "rollout-"+tt.name+".jsonl", tt.cwd)
+			repo, ok := r.Resolve(p)
+			if !ok {
+				t.Fatalf("Resolve(%q) ok = false, want true", p)
+			}
+			if repo != tt.want {
+				t.Errorf("Resolve(cwd=%q) = %q, want %q", tt.cwd, repo, tt.want)
+			}
+		})
+	}
+}
+
+// TestResolver_ClaudeSiblingNamePrefix guards the encoded-prefix boundary: a
+// project dir for /path/repo2x must not match discovered repo /path/repo2 even
+// though the raw string shares a prefix.
+func TestResolver_ClaudeSiblingNamePrefix(t *testing.T) {
+	f := newActivityFixture(t)
+	sibling := f.repo1 + "x" // e.g. .../repo1x next to .../repo1
+	if err := os.MkdirAll(sibling, 0o755); err != nil {
+		t.Fatalf("failed to create sibling dir: %v", err)
+	}
+
+	r := NewResolver(f.repos(), f.roots)
+	event := filepath.Join(f.roots.Claude, claudecode.EncodeProjectDirName(sibling), "s.jsonl")
+	if repo, ok := r.Resolve(event); ok {
+		t.Errorf("Resolve(%q) = %q, want no match for sibling-named project", event, repo)
+	}
+}

--- a/specstory-cli/pkg/monitor/child_exec.go
+++ b/specstory-cli/pkg/monitor/child_exec.go
@@ -1,0 +1,39 @@
+package monitor
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+)
+
+// osExecutable is swappable in tests so SpawnWatch can launch a stub binary
+// instead of recursively spawning real specstory processes. Mirrors the
+// package-level mocking pattern used by pkg/providers/codexcli.
+var osExecutable = os.Executable
+
+// SpawnWatch starts a `specstory watch` child for projectPath and returns the
+// started command (cmd.Start convention, matching the provider *_exec.go
+// files — the caller reaps it with Wait). The child gets:
+//
+//   - cmd.Dir = projectPath, which is critical: watch scopes everything (its
+//     provider watchers, project identity, history) to its own cwd.
+//   - --output-dir inside the project so markdown lands in that repo's
+//     .specstory/history, and NOTHING else — the child follows the user's own
+//     config for cloud sync, redaction, logging, etc.
+//   - stdout/stderr discarded (nil → /dev/null): children have their own
+//     --log config; they must not spam the monitor's console.
+func SpawnWatch(projectPath string) (*exec.Cmd, error) {
+	exe, err := osExecutable()
+	if err != nil {
+		return nil, fmt.Errorf("failed to locate specstory executable: %w", err)
+	}
+
+	cmd := exec.Command(exe, "watch", "--output-dir", filepath.Join(projectPath, ".specstory", "history"))
+	cmd.Dir = projectPath
+
+	if err := cmd.Start(); err != nil {
+		return nil, fmt.Errorf("failed to start watch child for %s: %w", projectPath, err)
+	}
+	return cmd, nil
+}

--- a/specstory-cli/pkg/monitor/child_exec_test.go
+++ b/specstory-cli/pkg/monitor/child_exec_test.go
@@ -1,0 +1,70 @@
+package monitor
+
+import (
+	"errors"
+	"path/filepath"
+	"reflect"
+	"testing"
+)
+
+func TestSpawnWatch(t *testing.T) {
+	tests := []struct {
+		name string
+		// exe/exeErr are what the injected os.Executable stub returns. The
+		// happy path uses /bin/echo so no real specstory child is spawned.
+		exe     string
+		exeErr  error
+		wantErr bool
+	}{
+		{
+			name: "builds expected argv and dir",
+			exe:  "/bin/echo",
+		},
+		{
+			name:    "executable lookup failure",
+			exeErr:  errors.New("no executable"),
+			wantErr: true,
+		},
+		{
+			name:    "start failure for missing binary",
+			exe:     "/nonexistent/specstory-binary",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			orig := osExecutable
+			defer func() { osExecutable = orig }()
+			osExecutable = func() (string, error) { return tt.exe, tt.exeErr }
+
+			projectPath := t.TempDir()
+			cmd, err := SpawnWatch(projectPath)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("SpawnWatch() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if tt.wantErr {
+				return
+			}
+
+			wantArgs := []string{
+				tt.exe,
+				"watch",
+				"--output-dir", filepath.Join(projectPath, ".specstory", "history"),
+			}
+			if !reflect.DeepEqual(cmd.Args, wantArgs) {
+				t.Errorf("SpawnWatch() args = %v, want %v", cmd.Args, wantArgs)
+			}
+			if cmd.Dir != projectPath {
+				t.Errorf("SpawnWatch() Dir = %q, want %q", cmd.Dir, projectPath)
+			}
+			if cmd.Process == nil {
+				t.Error("SpawnWatch() did not start the process (Process is nil)")
+			}
+			// Reap the stub so the test leaves no zombie behind.
+			if err := cmd.Wait(); err != nil {
+				t.Errorf("stub child exited with error: %v", err)
+			}
+		})
+	}
+}

--- a/specstory-cli/pkg/monitor/copilotwatch.go
+++ b/specstory-cli/pkg/monitor/copilotwatch.go
@@ -1,0 +1,301 @@
+//go:build copilotide_monitor
+
+package monitor
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/fsnotify/fsnotify"
+
+	"github.com/specstoryai/getspecstory/specstory-cli/pkg/providers/copilotide"
+)
+
+// copilotWorkspaceJSONRetries and copilotWorkspaceJSONRetryDelay bound the
+// wait for workspace.json inside a freshly created workspace directory: VS
+// Code creates the directory first and writes workspace.json asynchronously,
+// so an immediate read races that write and would permanently miss the
+// workspace. ~2s total is generous for a local write. The delay is a var so
+// tests can shrink it instead of sleeping for real.
+const copilotWorkspaceJSONRetries = 10
+
+var copilotWorkspaceJSONRetryDelay = 200 * time.Millisecond
+
+// WatchCopilotWorkspaceStorage watches one VS Code variant's workspaceStorage
+// directory for Copilot chat activity and reports the owning discovered repo
+// via onActivity, until ctx is cancelled.
+//
+// This deliberately does NOT reuse WatchRootForNewEntries: workspaceStorage
+// commonly holds thousands of per-workspace directories and fsnotify costs a
+// file descriptor per watched directory (kqueue on macOS), so watching the
+// whole tree would exhaust descriptors. Instead:
+//
+//   - workspaceStorage is enumerated ONCE at startup; each workspace.json is
+//     resolved to its project folder(s) and only workspaces mapping into the
+//     discovered-repo set are kept (typically tens of matches), and
+//   - fsnotify watches only those workspaces' chatSessions directories, plus
+//     the workspaceStorage root itself (a single watch) so workspace
+//     directories created while the monitor runs are picked up too.
+//
+// A pre-existing matched workspace with no chatSessions directory yet is
+// skipped at startup (fsnotify cannot watch a missing path); its first-ever
+// chat is picked up on the next monitor run. Workspace directories created at
+// runtime DO get chatSessions-creation tracking — via a temporary watch on
+// the workspace directory itself — because at creation time chatSessions
+// never exists yet and the root watch alone would never see it appear.
+func WatchCopilotWorkspaceStorage(ctx context.Context, storageRoot string, resolver *Resolver, onActivity func(repo string)) error {
+	watcher, err := fsnotify.NewWatcher()
+	if err != nil {
+		return err
+	}
+	defer func() {
+		_ = watcher.Close() // Best-effort cleanup; nothing to do if closing fails.
+	}()
+
+	root := filepath.Clean(storageRoot)
+	if err := watcher.Add(root); err != nil {
+		return err
+	}
+
+	// chatDirToRepo maps each watched chatSessions directory to its repo;
+	// any Create/Write inside those directories is chat activity for that repo.
+	chatDirToRepo, err := mapCopilotWorkspaces(root, resolver)
+	if err != nil {
+		return err
+	}
+	for chatDir := range chatDirToRepo {
+		if addErr := watcher.Add(chatDir); addErr != nil {
+			// One unwatchable directory must not take down the variant's whole
+			// watch; drop the mapping so events can't be misattributed later.
+			slog.Warn("Monitor: failed to watch Copilot chatSessions dir", "path", chatDir, "error", addErr)
+			delete(chatDirToRepo, chatDir)
+		}
+	}
+	slog.Info("Monitor: watching Copilot workspace storage", "root", root, "matchedWorkspaces", len(chatDirToRepo))
+
+	// pendingWorkspaces maps runtime-created, repo-matched workspace
+	// directories — watched while their chatSessions dir does not exist yet —
+	// to their repo.
+	pendingWorkspaces := make(map[string]string)
+
+	// resolvedWorkspace carries a repo resolution for a runtime-created
+	// workspace directory back into the event loop, so the retrying (sleeping)
+	// workspace.json read never blocks event processing.
+	type resolvedWorkspace struct {
+		wsDir string
+		repo  string
+		ok    bool
+	}
+	newWorkspaces := make(chan resolvedWorkspace)
+	// resolving de-dupes concurrent resolution attempts for the same new
+	// directory (fsnotify can deliver more than one event for a creation).
+	resolving := make(map[string]bool)
+
+	for {
+		select {
+		case <-ctx.Done():
+			// Cancellation is the normal way to stop watching, not an error.
+			return nil
+
+		case ws := <-newWorkspaces:
+			delete(resolving, ws.wsDir)
+			if !ws.ok {
+				continue
+			}
+			chatDir := copilotide.GetChatSessionsPath(ws.wsDir)
+			if _, statErr := os.Stat(chatDir); statErr == nil {
+				if addErr := watcher.Add(chatDir); addErr != nil {
+					slog.Warn("Monitor: failed to watch Copilot chatSessions dir", "path", chatDir, "error", addErr)
+					continue
+				}
+				chatDirToRepo[chatDir] = ws.repo
+				continue
+			}
+			// chatSessions does not exist yet — the workspace was just created
+			// and the first chat may be minutes away. Watch the workspace dir
+			// itself so the chatSessions creation is observed and promoted.
+			if addErr := watcher.Add(ws.wsDir); addErr != nil {
+				slog.Warn("Monitor: failed to watch new Copilot workspace dir", "path", ws.wsDir, "error", addErr)
+				continue
+			}
+			pendingWorkspaces[ws.wsDir] = ws.repo
+
+		case event, ok := <-watcher.Events:
+			if !ok {
+				return nil
+			}
+			// Create covers new session files and directories; Write covers
+			// appends to an existing session file (same rationale as
+			// WatchRootForNewEntries).
+			if !event.Has(fsnotify.Create) && !event.Has(fsnotify.Write) {
+				continue
+			}
+			parent := filepath.Dir(event.Name)
+
+			// Activity inside a watched chatSessions dir → the mapped repo.
+			if repo, mapped := chatDirToRepo[parent]; mapped {
+				onActivity(repo)
+				continue
+			}
+
+			// chatSessions dir created inside a pending workspace: promote the
+			// workspace-dir watch to a chatSessions watch. The creation itself
+			// counts as activity — VS Code creates chatSessions when the first
+			// chat message is sent — and firing now also covers a session file
+			// written in the instant before the new watch lands.
+			if repo, pending := pendingWorkspaces[parent]; pending {
+				if filepath.Base(event.Name) != "chatSessions" {
+					continue
+				}
+				if addErr := watcher.Add(event.Name); addErr != nil {
+					slog.Warn("Monitor: failed to watch new Copilot chatSessions dir", "path", event.Name, "error", addErr)
+					continue
+				}
+				chatDirToRepo[event.Name] = repo
+				delete(pendingWorkspaces, parent)
+				// The workspace-dir watch has served its purpose; drop it to
+				// return the file descriptor.
+				_ = watcher.Remove(parent)
+				onActivity(repo)
+				continue
+			}
+
+			// A new entry directly under workspaceStorage: possibly a
+			// workspace directory VS Code just created for a newly opened
+			// folder. Resolve it off-loop (workspace.json arrives async).
+			if parent == root && !resolving[event.Name] {
+				info, statErr := os.Stat(event.Name)
+				if statErr != nil || !info.IsDir() {
+					continue
+				}
+				resolving[event.Name] = true
+				wsDir := event.Name
+				go func() {
+					repo, resolvedOK := resolveNewCopilotWorkspace(ctx, wsDir, resolver)
+					select {
+					case newWorkspaces <- resolvedWorkspace{wsDir: wsDir, repo: repo, ok: resolvedOK}:
+					case <-ctx.Done():
+					}
+				}()
+			}
+
+		case watchErr, ok := <-watcher.Errors:
+			if !ok {
+				return nil
+			}
+			// Watcher errors are usually transient (overflow, races); keep
+			// watching rather than tearing down the whole monitor.
+			slog.Warn("Monitor: Copilot workspace watcher error", "root", root, "error", watchErr)
+		}
+	}
+}
+
+// mapCopilotWorkspaces enumerates every workspace directory under root ONCE
+// and returns chatSessions-dir → repo for the workspaces that both map into
+// the discovered-repo set and already have a chatSessions directory. This
+// single ReadDir pass (instead of per-directory watches) is what keeps the
+// monitor's file-descriptor usage independent of workspaceStorage size.
+func mapCopilotWorkspaces(root string, resolver *Resolver) (map[string]string, error) {
+	entries, err := os.ReadDir(root)
+	if err != nil {
+		return nil, err
+	}
+
+	chatDirToRepo := make(map[string]string)
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		wsDir := filepath.Join(root, entry.Name())
+		repo, ok, wsErr := copilotWorkspaceRepo(wsDir, resolver)
+		if wsErr != nil || !ok {
+			continue
+		}
+		chatDir := copilotide.GetChatSessionsPath(wsDir)
+		if _, statErr := os.Stat(chatDir); statErr != nil {
+			// No chat has ever happened in this workspace; skipped because
+			// fsnotify cannot watch a missing directory (see the
+			// WatchCopilotWorkspaceStorage doc comment).
+			slog.Debug("Monitor: matched Copilot workspace has no chatSessions dir; skipping", "workspace", wsDir, "repo", repo)
+			continue
+		}
+		chatDirToRepo[chatDir] = repo
+	}
+	return chatDirToRepo, nil
+}
+
+// copilotWorkspaceRepo resolves a workspace directory's workspace.json to the
+// discovered repo its project folder lives in. Returns err when
+// workspace.json is missing or unreadable — retryable, because VS Code writes
+// it asynchronously after creating the directory — and ok=false with err=nil
+// when the workspace resolves cleanly but maps to no discovered repo (an
+// answer that will not change on retry).
+//
+// A multi-root (.code-workspace) workspace maps to the FIRST listed folder
+// that falls inside a discovered repo: a chat event path alone cannot tell
+// which folder of the window it belongs to, so one deterministic attribution
+// is the best available.
+func copilotWorkspaceRepo(wsDir string, resolver *Resolver) (string, bool, error) {
+	ws, err := copilotide.ReadWorkspaceJSON(copilotide.GetWorkspaceMetadataPath(wsDir))
+	if err != nil {
+		return "", false, err
+	}
+
+	// Prefer workspace over folder, mirroring the copilotide provider's own
+	// workspace matching.
+	uri := ws.Workspace
+	if uri == "" {
+		uri = ws.Folder
+	}
+	if uri == "" {
+		// Valid JSON with neither field (e.g. an untitled workspace): not
+		// retryable, just unmappable.
+		return "", false, nil
+	}
+
+	p, err := copilotide.URIToPath(uri)
+	if err != nil {
+		// Non-file URIs (remote workspaces etc.) can never map to a local repo.
+		return "", false, nil
+	}
+
+	if strings.HasSuffix(p, ".code-workspace") {
+		for _, folder := range copilotide.CollectCodeWorkspaceFolders(p) {
+			if repo, ok := resolver.repoContaining(folder); ok {
+				return repo, true, nil
+			}
+		}
+		return "", false, nil
+	}
+
+	repo, ok := resolver.repoContaining(p)
+	return repo, ok, nil
+}
+
+// resolveNewCopilotWorkspace maps a freshly created workspace directory to a
+// discovered repo, retrying while workspace.json is missing or unparsable
+// (VS Code writes it a moment after creating the directory). It stops early —
+// without burning the remaining retries — once a valid workspace.json maps to
+// a path outside every discovered repo.
+func resolveNewCopilotWorkspace(ctx context.Context, wsDir string, resolver *Resolver) (string, bool) {
+	for attempt := 0; attempt < copilotWorkspaceJSONRetries; attempt++ {
+		if attempt > 0 {
+			select {
+			case <-ctx.Done():
+				return "", false
+			case <-time.After(copilotWorkspaceJSONRetryDelay):
+			}
+		}
+		repo, ok, err := copilotWorkspaceRepo(wsDir, resolver)
+		if err != nil {
+			continue // workspace.json not written yet; retry.
+		}
+		return repo, ok
+	}
+	slog.Debug("Monitor: gave up waiting for workspace.json in new Copilot workspace dir", "path", wsDir)
+	return "", false
+}

--- a/specstory-cli/pkg/monitor/copilotwatch_test.go
+++ b/specstory-cli/pkg/monitor/copilotwatch_test.go
@@ -1,0 +1,388 @@
+//go:build copilotide_monitor
+
+package monitor
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// copilotRoot returns the fixture's stock-VS-Code workspaceStorage root.
+func (f *activityFixture) copilotRoot() string {
+	return f.roots.CopilotIDE["copilotide"]
+}
+
+// writeCopilotWorkspace creates a fake VS Code workspace-storage entry:
+// <root>/<id>/workspace.json (content given verbatim; "" means no file) and,
+// optionally, an empty chatSessions directory. Returns the workspace dir.
+func writeCopilotWorkspace(t *testing.T, root, id, workspaceJSON string, withChatSessions bool) string {
+	t.Helper()
+	wsDir := filepath.Join(root, id)
+	if err := os.MkdirAll(wsDir, 0o755); err != nil {
+		t.Fatalf("failed to create workspace dir: %v", err)
+	}
+	if workspaceJSON != "" {
+		if err := os.WriteFile(filepath.Join(wsDir, "workspace.json"), []byte(workspaceJSON), 0o644); err != nil {
+			t.Fatalf("failed to write workspace.json: %v", err)
+		}
+	}
+	if withChatSessions {
+		if err := os.MkdirAll(filepath.Join(wsDir, "chatSessions"), 0o755); err != nil {
+			t.Fatalf("failed to create chatSessions dir: %v", err)
+		}
+	}
+	return wsDir
+}
+
+// folderJSON builds a workspace.json body whose "folder" URI points at path.
+func folderJSON(path string) string {
+	return fmt.Sprintf(`{"folder":"file://%s"}`, path)
+}
+
+// writeCodeWorkspaceFile writes a .code-workspace file listing the given
+// folders (absolute paths) and returns a workspace.json body referencing it.
+func writeCodeWorkspaceFile(t *testing.T, dir string, folders ...string) string {
+	t.Helper()
+	body := `{"folders":[`
+	for i, f := range folders {
+		if i > 0 {
+			body += ","
+		}
+		body += fmt.Sprintf(`{"path":%q}`, f)
+	}
+	body += `]}`
+	wsFile := filepath.Join(dir, "multi.code-workspace")
+	if err := os.WriteFile(wsFile, []byte(body), 0o644); err != nil {
+		t.Fatalf("failed to write .code-workspace file: %v", err)
+	}
+	return fmt.Sprintf(`{"workspace":"file://%s"}`, wsFile)
+}
+
+func TestMapCopilotWorkspaces(t *testing.T) {
+	tests := []struct {
+		name string
+		// workspaceJSON returns the workspace.json body ("" = no file).
+		workspaceJSON    func(t *testing.T, f *activityFixture) string
+		withChatSessions bool
+		// wantRepo returns the repo the workspace must map to ("" = excluded).
+		wantRepo func(f *activityFixture) string
+	}{
+		{
+			name:             "folder is repo root",
+			workspaceJSON:    func(t *testing.T, f *activityFixture) string { return folderJSON(f.repo1) },
+			withChatSessions: true,
+			wantRepo:         func(f *activityFixture) string { return f.repo1 },
+		},
+		{
+			name:             "folder is repo subdirectory (longest-prefix mapping)",
+			workspaceJSON:    func(t *testing.T, f *activityFixture) string { return folderJSON(f.repo2Sub) },
+			withChatSessions: true,
+			wantRepo:         func(f *activityFixture) string { return f.repo2 },
+		},
+		{
+			name: "folder outside every discovered repo is excluded",
+			workspaceJSON: func(t *testing.T, f *activityFixture) string {
+				return folderJSON(t.TempDir())
+			},
+			withChatSessions: true,
+			wantRepo:         func(f *activityFixture) string { return "" },
+		},
+		{
+			name: "code-workspace with one folder inside a repo",
+			workspaceJSON: func(t *testing.T, f *activityFixture) string {
+				// First folder is outside the repo set; the second maps into
+				// repo2 — the first matching folder wins.
+				return writeCodeWorkspaceFile(t, t.TempDir(), t.TempDir(), f.repo2Sub)
+			},
+			withChatSessions: true,
+			wantRepo:         func(f *activityFixture) string { return f.repo2 },
+		},
+		{
+			name: "code-workspace with no folder in the repo set is excluded",
+			workspaceJSON: func(t *testing.T, f *activityFixture) string {
+				return writeCodeWorkspaceFile(t, t.TempDir(), t.TempDir(), t.TempDir())
+			},
+			withChatSessions: true,
+			wantRepo:         func(f *activityFixture) string { return "" },
+		},
+		{
+			name:             "missing workspace.json is skipped",
+			workspaceJSON:    func(t *testing.T, f *activityFixture) string { return "" },
+			withChatSessions: true,
+			wantRepo:         func(f *activityFixture) string { return "" },
+		},
+		{
+			name:             "invalid workspace.json is skipped",
+			workspaceJSON:    func(t *testing.T, f *activityFixture) string { return "{not json" },
+			withChatSessions: true,
+			wantRepo:         func(f *activityFixture) string { return "" },
+		},
+		{
+			name: "non-file URI is skipped",
+			workspaceJSON: func(t *testing.T, f *activityFixture) string {
+				return `{"folder":"vscode-remote://ssh-remote%2Bhost/home/user/repo"}`
+			},
+			withChatSessions: true,
+			wantRepo:         func(f *activityFixture) string { return "" },
+		},
+		{
+			name:             "matched workspace without chatSessions dir is skipped",
+			workspaceJSON:    func(t *testing.T, f *activityFixture) string { return folderJSON(f.repo1) },
+			withChatSessions: false,
+			wantRepo:         func(f *activityFixture) string { return "" },
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f := newActivityFixture(t)
+			root := f.copilotRoot()
+			wsDir := writeCopilotWorkspace(t, root, "ws-under-test", tt.workspaceJSON(t, f), tt.withChatSessions)
+
+			got, err := mapCopilotWorkspaces(root, NewResolver(f.repos(), f.roots))
+			if err != nil {
+				t.Fatalf("mapCopilotWorkspaces() error = %v", err)
+			}
+
+			wantRepo := tt.wantRepo(f)
+			chatDir := filepath.Join(wsDir, "chatSessions")
+			if wantRepo == "" {
+				if len(got) != 0 {
+					t.Errorf("mapCopilotWorkspaces() = %v, want empty map", got)
+				}
+				return
+			}
+			if len(got) != 1 || got[chatDir] != wantRepo {
+				t.Errorf("mapCopilotWorkspaces() = %v, want {%q: %q}", got, chatDir, wantRepo)
+			}
+		})
+	}
+}
+
+// TestMapCopilotWorkspaces_ManyEntries pins that the enumeration keeps only
+// repo-relevant workspaces out of a larger population — the property that
+// bounds the fsnotify watch count regardless of workspaceStorage size.
+func TestMapCopilotWorkspaces_ManyEntries(t *testing.T) {
+	f := newActivityFixture(t)
+	root := f.copilotRoot()
+
+	outside := t.TempDir()
+	for i := 0; i < 25; i++ {
+		writeCopilotWorkspace(t, root, fmt.Sprintf("outside-%d", i), folderJSON(outside), true)
+	}
+	matched := writeCopilotWorkspace(t, root, "matched", folderJSON(f.repo1), true)
+
+	got, err := mapCopilotWorkspaces(root, NewResolver(f.repos(), f.roots))
+	if err != nil {
+		t.Fatalf("mapCopilotWorkspaces() error = %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("mapCopilotWorkspaces() kept %d workspaces, want 1: %v", len(got), got)
+	}
+	if got[filepath.Join(matched, "chatSessions")] != f.repo1 {
+		t.Errorf("mapCopilotWorkspaces() = %v, want the matched workspace mapping to %q", got, f.repo1)
+	}
+}
+
+// startCopilotWatch runs WatchCopilotWorkspaceStorage in a goroutine and gives
+// the watcher a moment to establish before the test generates events (same
+// pattern as startRootWatch).
+func startCopilotWatch(t *testing.T, ctx context.Context, root string, r *Resolver, onActivity func(string)) chan error {
+	t.Helper()
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- WatchCopilotWorkspaceStorage(ctx, root, r, onActivity)
+	}()
+	time.Sleep(250 * time.Millisecond)
+	return errCh
+}
+
+// stopCopilotWatch cancels the watcher and asserts it returns cleanly.
+func stopCopilotWatch(t *testing.T, cancel context.CancelFunc, errCh chan error) {
+	t.Helper()
+	cancel()
+	select {
+	case err := <-errCh:
+		if err != nil {
+			t.Errorf("WatchCopilotWorkspaceStorage() error = %v, want nil on cancellation", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Error("WatchCopilotWorkspaceStorage() did not return after context cancellation")
+	}
+}
+
+func TestWatchCopilotWorkspaceStorage_ChatSessionEvent(t *testing.T) {
+	f := newActivityFixture(t)
+	root := f.copilotRoot()
+	wsDir := writeCopilotWorkspace(t, root, "ws1", folderJSON(f.repo1), true)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	rec := &eventRecorder{}
+	errCh := startCopilotWatch(t, ctx, root, NewResolver(f.repos(), f.roots), rec.record)
+
+	// A new session file in the pre-mapped chatSessions dir is activity.
+	sessionFile := filepath.Join(wsDir, "chatSessions", "0198c5c1-abcd.jsonl")
+	if err := os.WriteFile(sessionFile, []byte("{}\n"), 0o644); err != nil {
+		t.Fatalf("failed to write session file: %v", err)
+	}
+	waitFor(t, 5*time.Second, func() bool { return rec.contains(f.repo1) },
+		"onActivity never observed "+f.repo1)
+
+	stopCopilotWatch(t, cancel, errCh)
+}
+
+func TestWatchCopilotWorkspaceStorage_NewWorkspaceDirAppears(t *testing.T) {
+	// Shrink the workspace.json retry delay so the async-write simulation
+	// below doesn't slow the suite down.
+	savedDelay := copilotWorkspaceJSONRetryDelay
+	copilotWorkspaceJSONRetryDelay = 20 * time.Millisecond
+	defer func() { copilotWorkspaceJSONRetryDelay = savedDelay }()
+
+	f := newActivityFixture(t)
+	root := f.copilotRoot()
+	outside := t.TempDir()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	rec := &eventRecorder{}
+	errCh := startCopilotWatch(t, ctx, root, NewResolver(f.repos(), f.roots), rec.record)
+
+	// A workspace for a folder OUTSIDE the repo set appears first; it must
+	// never produce a notification even once its chat starts.
+	outsideWS := writeCopilotWorkspace(t, root, "ws-outside", folderJSON(outside), false)
+	time.Sleep(300 * time.Millisecond)
+	if err := os.MkdirAll(filepath.Join(outsideWS, "chatSessions"), 0o755); err != nil {
+		t.Fatalf("failed to create outside chatSessions: %v", err)
+	}
+
+	// A repo-mapped workspace appears the way VS Code creates one: directory
+	// first, workspace.json a moment later (exercising the retry loop), and
+	// the chatSessions dir only when the first chat starts.
+	wsDir := filepath.Join(root, "ws-new")
+	if err := os.Mkdir(wsDir, 0o755); err != nil {
+		t.Fatalf("failed to create new workspace dir: %v", err)
+	}
+	time.Sleep(60 * time.Millisecond) // Let a first workspace.json read fail.
+	if err := os.WriteFile(filepath.Join(wsDir, "workspace.json"), []byte(folderJSON(f.repo1)), 0o644); err != nil {
+		t.Fatalf("failed to write workspace.json: %v", err)
+	}
+	// Give the resolver time to finish and register the pending-workspace
+	// watch before the first chat "starts".
+	time.Sleep(300 * time.Millisecond)
+	if err := os.Mkdir(filepath.Join(wsDir, "chatSessions"), 0o755); err != nil {
+		t.Fatalf("failed to create chatSessions: %v", err)
+	}
+
+	// The chatSessions creation itself must register as activity.
+	waitFor(t, 5*time.Second, func() bool { return rec.contains(f.repo1) },
+		"onActivity never observed "+f.repo1+" after chatSessions creation")
+
+	// And subsequent session-file writes keep flowing through the promoted
+	// chatSessions watch.
+	before := rec.count(f.repo1)
+	if err := os.WriteFile(filepath.Join(wsDir, "chatSessions", "s1.jsonl"), []byte("{}\n"), 0o644); err != nil {
+		t.Fatalf("failed to write session file: %v", err)
+	}
+	waitFor(t, 5*time.Second, func() bool { return rec.count(f.repo1) > before },
+		"onActivity never observed session-file activity in the promoted chatSessions dir")
+
+	// The outside workspace must not have produced any notification.
+	if rec.contains(outside) {
+		t.Errorf("onActivity observed %q, want no notifications for a workspace outside the repo set", outside)
+	}
+
+	stopCopilotWatch(t, cancel, errCh)
+}
+
+// TestWatchCopilotWorkspaceStorage_NewWorkspaceWithExistingChatSessions covers
+// the runtime path where the new workspace directory already has chatSessions
+// by the time workspace.json resolves (e.g. the monitor raced a fast setup).
+func TestWatchCopilotWorkspaceStorage_NewWorkspaceWithExistingChatSessions(t *testing.T) {
+	savedDelay := copilotWorkspaceJSONRetryDelay
+	copilotWorkspaceJSONRetryDelay = 20 * time.Millisecond
+	defer func() { copilotWorkspaceJSONRetryDelay = savedDelay }()
+
+	f := newActivityFixture(t)
+	root := f.copilotRoot()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	rec := &eventRecorder{}
+	errCh := startCopilotWatch(t, ctx, root, NewResolver(f.repos(), f.roots), rec.record)
+
+	// Fully formed workspace appears in one go.
+	wsDir := writeCopilotWorkspace(t, root, "ws-fast", folderJSON(f.repo2), true)
+	time.Sleep(300 * time.Millisecond) // Let the watcher resolve and add the chatSessions watch.
+
+	if err := os.WriteFile(filepath.Join(wsDir, "chatSessions", "s1.jsonl"), []byte("{}\n"), 0o644); err != nil {
+		t.Fatalf("failed to write session file: %v", err)
+	}
+	waitFor(t, 5*time.Second, func() bool { return rec.contains(f.repo2) },
+		"onActivity never observed "+f.repo2)
+
+	stopCopilotWatch(t, cancel, errCh)
+}
+
+func TestResolveNewCopilotWorkspace_RetriesUntilWorkspaceJSONAppears(t *testing.T) {
+	savedDelay := copilotWorkspaceJSONRetryDelay
+	copilotWorkspaceJSONRetryDelay = 20 * time.Millisecond
+	defer func() { copilotWorkspaceJSONRetryDelay = savedDelay }()
+
+	f := newActivityFixture(t)
+	r := NewResolver(f.repos(), f.roots)
+
+	tests := []struct {
+		name string
+		// delayedJSON is written after a delay ("" = never written).
+		delayedJSON string
+		wantRepo    string
+		wantOK      bool
+	}{
+		{
+			name:        "workspace.json arrives late and maps to a repo",
+			delayedJSON: folderJSON(f.repo1),
+			wantRepo:    f.repo1,
+			wantOK:      true,
+		},
+		{
+			name:        "workspace.json arrives late but maps outside the repo set",
+			delayedJSON: folderJSON(t.TempDir()),
+			wantOK:      false,
+		},
+		{
+			name:   "workspace.json never arrives",
+			wantOK: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			wsDir := filepath.Join(f.copilotRoot(), "retry-"+tt.name)
+			if err := os.Mkdir(wsDir, 0o755); err != nil {
+				t.Fatalf("failed to create workspace dir: %v", err)
+			}
+			if tt.delayedJSON != "" {
+				go func() {
+					time.Sleep(3 * copilotWorkspaceJSONRetryDelay)
+					_ = os.WriteFile(filepath.Join(wsDir, "workspace.json"), []byte(tt.delayedJSON), 0o644)
+				}()
+			}
+
+			repo, ok := resolveNewCopilotWorkspace(context.Background(), wsDir, r)
+			if ok != tt.wantOK {
+				t.Fatalf("resolveNewCopilotWorkspace() ok = %v, want %v (repo=%q)", ok, tt.wantOK, repo)
+			}
+			if ok && repo != tt.wantRepo {
+				t.Errorf("resolveNewCopilotWorkspace() = %q, want %q", repo, tt.wantRepo)
+			}
+		})
+	}
+}

--- a/specstory-cli/pkg/monitor/discover.go
+++ b/specstory-cli/pkg/monitor/discover.go
@@ -1,0 +1,111 @@
+// Package monitor implements the `specstory monitor` supervisor: it discovers
+// git repositories under a root directory, watches the agent-side session
+// storage roots (Claude Code, Codex CLI, Cursor CLI) for new activity, maps
+// that activity back to a discovered repository, and spawns/reaps child
+// `specstory watch` processes per active repository.
+package monitor
+
+import (
+	"io/fs"
+	"log/slog"
+	"os"
+	"path"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// alwaysSkipDirs are directory names never worth descending into: they either
+// can't contain the user's own repos (dependency trees) or are repo internals.
+var alwaysSkipDirs = map[string]bool{
+	"node_modules": true,
+	"vendor":       true,
+	".git":         true,
+}
+
+// DiscoverRepos walks root (depth 0) up to maxDepth levels deep and returns
+// the git repository roots it finds, sorted. A directory counts as a repo root
+// when it contains a .git entry — directory OR file, because worktrees and
+// submodules use a .git file pointing at the real git dir. Discovery does not
+// descend into a repo (nested repos inside another repo are the outer repo's
+// concern, handled by its own watch child). excludes are path globs matched
+// with path.Match against the slash-separated path relative to root; matching
+// directories and everything under them are skipped.
+func DiscoverRepos(root string, maxDepth int, excludes []string) ([]string, error) {
+	root = filepath.Clean(root)
+
+	var repos []string
+	walkErr := filepath.WalkDir(root, func(p string, d fs.DirEntry, err error) error {
+		if err != nil {
+			// An unreadable/missing root means there is nothing to discover at
+			// all — that must surface. Deeper unreadable entries (permissions,
+			// races) shouldn't abort discovery of everything else; log and move on.
+			if p == root {
+				return err
+			}
+			slog.Warn("DiscoverRepos: skipping unreadable entry", "path", p, "error", err)
+			if d != nil && d.IsDir() {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if !d.IsDir() {
+			return nil
+		}
+		if p == root {
+			// The root itself may be a repo; check it like any other directory
+			// but never exclude/skip it (depth 0 is always in range).
+			if isRepoRoot(p) {
+				repos = append(repos, p)
+				return filepath.SkipDir
+			}
+			return nil
+		}
+
+		if alwaysSkipDirs[d.Name()] {
+			return filepath.SkipDir
+		}
+
+		rel, relErr := filepath.Rel(root, p)
+		if relErr != nil {
+			// Should be impossible since p is under root; skip defensively.
+			return filepath.SkipDir
+		}
+		rel = filepath.ToSlash(rel)
+
+		for _, glob := range excludes {
+			// path.Match errors only on malformed patterns; a bad pattern
+			// simply never matches (the CLI can't do anything smarter mid-walk).
+			if matched, _ := path.Match(glob, rel); matched {
+				return filepath.SkipDir
+			}
+		}
+
+		// Depth of root is 0, so depth == number of separators in rel + 1.
+		depth := strings.Count(rel, "/") + 1
+		if depth > maxDepth {
+			return filepath.SkipDir
+		}
+
+		if isRepoRoot(p) {
+			repos = append(repos, p)
+			// Don't descend into a discovered repo: its own watch child covers
+			// everything inside it, including nested repos/worktrees.
+			return filepath.SkipDir
+		}
+		return nil
+	})
+	if walkErr != nil {
+		return nil, walkErr
+	}
+
+	sort.Strings(repos)
+	return repos, nil
+}
+
+// isRepoRoot reports whether dir contains a .git entry. Both a .git directory
+// (normal clone) and a .git file (worktree/submodule pointer) count.
+func isRepoRoot(dir string) bool {
+	_, err := os.Stat(filepath.Join(dir, ".git"))
+	return err == nil
+}

--- a/specstory-cli/pkg/monitor/discover_test.go
+++ b/specstory-cli/pkg/monitor/discover_test.go
@@ -1,0 +1,163 @@
+package monitor
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"sort"
+	"testing"
+)
+
+// mkGitRepo creates dir with a .git directory (gitFile=false) or a .git file
+// (gitFile=true, the worktree/submodule shape).
+func mkGitRepo(t *testing.T, dir string, gitFile bool) {
+	t.Helper()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("failed to create repo dir %s: %v", dir, err)
+	}
+	gitPath := filepath.Join(dir, ".git")
+	if gitFile {
+		if err := os.WriteFile(gitPath, []byte("gitdir: /elsewhere/.git/worktrees/x\n"), 0o644); err != nil {
+			t.Fatalf("failed to create .git file: %v", err)
+		}
+	} else {
+		if err := os.MkdirAll(gitPath, 0o755); err != nil {
+			t.Fatalf("failed to create .git dir: %v", err)
+		}
+	}
+}
+
+func TestDiscoverRepos(t *testing.T) {
+	tests := []struct {
+		name     string
+		setup    func(t *testing.T, root string)
+		maxDepth int
+		excludes []string
+		want     []string // relative to root; "." means the root itself
+	}{
+		{
+			name: "repos at various depths",
+			setup: func(t *testing.T, root string) {
+				mkGitRepo(t, filepath.Join(root, "a"), false)
+				mkGitRepo(t, filepath.Join(root, "group", "b"), false)
+				mkGitRepo(t, filepath.Join(root, "x", "y", "z", "c"), false)
+			},
+			maxDepth: 4,
+			want:     []string{"a", "group/b", "x/y/z/c"},
+		},
+		{
+			name: "git file counts as repo (worktree)",
+			setup: func(t *testing.T, root string) {
+				mkGitRepo(t, filepath.Join(root, "worktree"), true)
+			},
+			maxDepth: 4,
+			want:     []string{"worktree"},
+		},
+		{
+			name: "root itself is a repo",
+			setup: func(t *testing.T, root string) {
+				mkGitRepo(t, root, false)
+				// A nested repo must not be reported: discovery stops at the root repo.
+				mkGitRepo(t, filepath.Join(root, "inner"), false)
+			},
+			maxDepth: 4,
+			want:     []string{"."},
+		},
+		{
+			name: "does not descend into repos",
+			setup: func(t *testing.T, root string) {
+				mkGitRepo(t, filepath.Join(root, "outer"), false)
+				mkGitRepo(t, filepath.Join(root, "outer", "nested"), false)
+			},
+			maxDepth: 4,
+			want:     []string{"outer"},
+		},
+		{
+			name: "too deep is skipped",
+			setup: func(t *testing.T, root string) {
+				mkGitRepo(t, filepath.Join(root, "shallow"), false)
+				mkGitRepo(t, filepath.Join(root, "l1", "l2", "deep"), false)
+			},
+			maxDepth: 2,
+			want:     []string{"shallow"},
+		},
+		{
+			name: "repo at exactly maxDepth is found",
+			setup: func(t *testing.T, root string) {
+				mkGitRepo(t, filepath.Join(root, "l1", "edge"), false)
+			},
+			maxDepth: 2,
+			want:     []string{"l1/edge"},
+		},
+		{
+			name: "node_modules and vendor are always skipped",
+			setup: func(t *testing.T, root string) {
+				mkGitRepo(t, filepath.Join(root, "node_modules", "dep"), false)
+				mkGitRepo(t, filepath.Join(root, "vendor", "dep"), false)
+				mkGitRepo(t, filepath.Join(root, "real"), false)
+			},
+			maxDepth: 4,
+			want:     []string{"real"},
+		},
+		{
+			name: "excluded glob is skipped",
+			setup: func(t *testing.T, root string) {
+				mkGitRepo(t, filepath.Join(root, "archive", "old"), false)
+				mkGitRepo(t, filepath.Join(root, "scratch"), false)
+				mkGitRepo(t, filepath.Join(root, "keep"), false)
+			},
+			maxDepth: 4,
+			excludes: []string{"archive/*", "scratch"},
+			want:     []string{"keep"},
+		},
+		{
+			name: "exclude of parent skips everything under it",
+			setup: func(t *testing.T, root string) {
+				mkGitRepo(t, filepath.Join(root, "skipme", "a", "b"), false)
+				mkGitRepo(t, filepath.Join(root, "keep"), false)
+			},
+			maxDepth: 4,
+			excludes: []string{"skipme"},
+			want:     []string{"keep"},
+		},
+		{
+			name:     "empty tree finds nothing",
+			setup:    func(t *testing.T, root string) {},
+			maxDepth: 4,
+			want:     nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			root := t.TempDir()
+			tt.setup(t, root)
+
+			got, err := DiscoverRepos(root, tt.maxDepth, tt.excludes)
+			if err != nil {
+				t.Fatalf("DiscoverRepos() error = %v", err)
+			}
+
+			var want []string
+			for _, rel := range tt.want {
+				if rel == "." {
+					want = append(want, filepath.Clean(root))
+				} else {
+					want = append(want, filepath.Join(root, rel))
+				}
+			}
+			sort.Strings(want)
+
+			if !reflect.DeepEqual(got, want) {
+				t.Errorf("DiscoverRepos() = %v, want %v", got, want)
+			}
+		})
+	}
+}
+
+func TestDiscoverRepos_MissingRoot(t *testing.T) {
+	_, err := DiscoverRepos(filepath.Join(t.TempDir(), "does-not-exist"), 4, nil)
+	if err == nil {
+		t.Error("DiscoverRepos() on a missing root: expected error, got nil")
+	}
+}

--- a/specstory-cli/pkg/monitor/rootwatch.go
+++ b/specstory-cli/pkg/monitor/rootwatch.go
@@ -1,0 +1,102 @@
+package monitor
+
+import (
+	"context"
+	"io/fs"
+	"log/slog"
+	"os"
+	"path/filepath"
+
+	"github.com/fsnotify/fsnotify"
+)
+
+// WatchRootForNewEntries watches root for filesystem activity and invokes
+// onCreate with the affected path until ctx is cancelled. It generalizes the
+// provider-specific pattern in pkg/providers/claudecode/watcher.go without the
+// hardcoded name matching.
+//
+// Two deliberate extensions beyond a literal single-directory Create watcher,
+// both required for the monitor to see real agent activity:
+//
+//   - Subdirectories (existing and newly created) are watched too, because
+//     fsnotify is not recursive and activity lands inside them: a new session
+//     .jsonl appears inside an existing ~/.claude/projects/<dir>, Codex files
+//     sessions under a YYYY/MM/DD chain that materializes over time, and Cursor
+//     creates session dirs inside per-project hash dirs.
+//
+//   - Write events fire the callback as well as Create events, because agents
+//     append to the same session file for the lifetime of a session. If only
+//     Create counted, a reaped watch child would never be respawned while the
+//     user keeps working in an already-created session.
+//
+// Callback errors/filtering are the caller's concern: onCreate is invoked for
+// every event path and the caller's resolver decides what is interesting.
+func WatchRootForNewEntries(ctx context.Context, root string, onCreate func(path string)) error {
+	watcher, err := fsnotify.NewWatcher()
+	if err != nil {
+		return err
+	}
+	defer func() {
+		_ = watcher.Close() // Best-effort cleanup; nothing to do if closing fails.
+	}()
+
+	// Watch root and every existing subdirectory. Per-entry errors (permission
+	// denied, entries vanishing mid-walk) are logged and skipped so one bad
+	// directory can't take down the whole watch.
+	walkErr := filepath.WalkDir(root, func(p string, d fs.DirEntry, err error) error {
+		if err != nil {
+			// A missing/unreadable root means nothing can ever be watched —
+			// surface that instead of silently blocking forever. Deeper
+			// unreadable entries are logged and skipped.
+			if p == root {
+				return err
+			}
+			slog.Warn("WatchRootForNewEntries: skipping unreadable entry", "path", p, "error", err)
+			if d != nil && d.IsDir() {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if d.IsDir() {
+			if addErr := watcher.Add(p); addErr != nil {
+				slog.Warn("WatchRootForNewEntries: failed to watch directory", "path", p, "error", addErr)
+			}
+		}
+		return nil
+	})
+	if walkErr != nil {
+		return walkErr
+	}
+
+	for {
+		select {
+		case <-ctx.Done():
+			// Cancellation is the normal way to stop watching, not an error.
+			return nil
+		case event, ok := <-watcher.Events:
+			if !ok {
+				return nil
+			}
+			switch {
+			case event.Has(fsnotify.Create):
+				// A newly created directory must be watched immediately so
+				// activity inside it (the next Create/Write) is not missed.
+				if info, statErr := os.Stat(event.Name); statErr == nil && info.IsDir() {
+					if addErr := watcher.Add(event.Name); addErr != nil {
+						slog.Warn("WatchRootForNewEntries: failed to watch new directory", "path", event.Name, "error", addErr)
+					}
+				}
+				onCreate(event.Name)
+			case event.Has(fsnotify.Write):
+				onCreate(event.Name)
+			}
+		case watchErr, ok := <-watcher.Errors:
+			if !ok {
+				return nil
+			}
+			// Watcher errors are usually transient (overflow, races); keep
+			// watching rather than tearing down the whole monitor.
+			slog.Warn("WatchRootForNewEntries: watcher error", "root", root, "error", watchErr)
+		}
+	}
+}

--- a/specstory-cli/pkg/monitor/rootwatch_test.go
+++ b/specstory-cli/pkg/monitor/rootwatch_test.go
@@ -1,0 +1,201 @@
+package monitor
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+)
+
+// eventRecorder collects callback invocations thread-safely for assertions.
+type eventRecorder struct {
+	mu    sync.Mutex
+	paths []string
+}
+
+func (r *eventRecorder) record(path string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.paths = append(r.paths, path)
+}
+
+func (r *eventRecorder) contains(path string) bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	for _, p := range r.paths {
+		if p == path {
+			return true
+		}
+	}
+	return false
+}
+
+// count returns how many times path has been recorded, so tests can assert
+// that NEW events keep arriving after a state transition (contains alone
+// cannot distinguish old notifications from fresh ones).
+func (r *eventRecorder) count(path string) int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	n := 0
+	for _, p := range r.paths {
+		if p == path {
+			n++
+		}
+	}
+	return n
+}
+
+// waitFor polls cond until it is true or the (deliberately generous, for flake
+// resistance) timeout elapses.
+func waitFor(t *testing.T, timeout time.Duration, cond func() bool, msg string) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatal(msg)
+}
+
+// startRootWatch runs WatchRootForNewEntries in a goroutine and gives the
+// watcher a moment to establish before the test generates events.
+func startRootWatch(t *testing.T, ctx context.Context, root string, onCreate func(string)) chan error {
+	t.Helper()
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- WatchRootForNewEntries(ctx, root, onCreate)
+	}()
+	// The initial watch registration happens synchronously inside the
+	// goroutine; a short settle keeps event generation from racing it.
+	time.Sleep(250 * time.Millisecond)
+	return errCh
+}
+
+func TestWatchRootForNewEntries(t *testing.T) {
+	tests := []struct {
+		name string
+		// setup runs before the watcher starts (pre-existing state).
+		setup func(t *testing.T, root string)
+		// act generates events and returns the path the callback must see.
+		act func(t *testing.T, root string) string
+	}{
+		{
+			name:  "file created in root",
+			setup: func(t *testing.T, root string) {},
+			act: func(t *testing.T, root string) string {
+				p := filepath.Join(root, "new-entry")
+				if err := os.WriteFile(p, []byte("x"), 0o644); err != nil {
+					t.Fatalf("failed to create file: %v", err)
+				}
+				return p
+			},
+		},
+		{
+			name:  "directory created in root",
+			setup: func(t *testing.T, root string) {},
+			act: func(t *testing.T, root string) string {
+				p := filepath.Join(root, "new-dir")
+				if err := os.Mkdir(p, 0o755); err != nil {
+					t.Fatalf("failed to create dir: %v", err)
+				}
+				return p
+			},
+		},
+		{
+			name: "file created inside pre-existing subdirectory",
+			setup: func(t *testing.T, root string) {
+				if err := os.MkdirAll(filepath.Join(root, "sub"), 0o755); err != nil {
+					t.Fatalf("failed to create subdir: %v", err)
+				}
+			},
+			act: func(t *testing.T, root string) string {
+				p := filepath.Join(root, "sub", "inner-file")
+				if err := os.WriteFile(p, []byte("x"), 0o644); err != nil {
+					t.Fatalf("failed to create file: %v", err)
+				}
+				return p
+			},
+		},
+		{
+			name:  "file created inside newly created subdirectory",
+			setup: func(t *testing.T, root string) {},
+			act: func(t *testing.T, root string) string {
+				sub := filepath.Join(root, "made-later")
+				if err := os.Mkdir(sub, 0o755); err != nil {
+					t.Fatalf("failed to create dir: %v", err)
+				}
+				// Give the watcher time to pick up the new directory before
+				// writing into it (mirrors real agent behavior, which is never
+				// instantaneous either).
+				time.Sleep(250 * time.Millisecond)
+				p := filepath.Join(sub, "later-file")
+				if err := os.WriteFile(p, []byte("x"), 0o644); err != nil {
+					t.Fatalf("failed to create file: %v", err)
+				}
+				return p
+			},
+		},
+		{
+			name: "write to pre-existing file",
+			setup: func(t *testing.T, root string) {
+				if err := os.WriteFile(filepath.Join(root, "existing.jsonl"), []byte("a\n"), 0o644); err != nil {
+					t.Fatalf("failed to create file: %v", err)
+				}
+			},
+			act: func(t *testing.T, root string) string {
+				p := filepath.Join(root, "existing.jsonl")
+				f, err := os.OpenFile(p, os.O_APPEND|os.O_WRONLY, 0o644)
+				if err != nil {
+					t.Fatalf("failed to open file: %v", err)
+				}
+				if _, err := f.WriteString("b\n"); err != nil {
+					t.Fatalf("failed to append: %v", err)
+				}
+				if err := f.Close(); err != nil {
+					t.Fatalf("failed to close: %v", err)
+				}
+				return p
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			root := t.TempDir()
+			tt.setup(t, root)
+
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			rec := &eventRecorder{}
+			errCh := startRootWatch(t, ctx, root, rec.record)
+
+			want := tt.act(t, root)
+			waitFor(t, 5*time.Second, func() bool { return rec.contains(want) },
+				"callback never observed "+want)
+
+			cancel()
+			select {
+			case err := <-errCh:
+				if err != nil {
+					t.Errorf("WatchRootForNewEntries() error = %v, want nil on cancellation", err)
+				}
+			case <-time.After(5 * time.Second):
+				t.Error("WatchRootForNewEntries() did not return after context cancellation")
+			}
+		})
+	}
+}
+
+func TestWatchRootForNewEntries_MissingRoot(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	err := WatchRootForNewEntries(ctx, filepath.Join(t.TempDir(), "nope"), func(string) {})
+	if err == nil {
+		t.Error("WatchRootForNewEntries() on a missing root: expected error, got nil")
+	}
+}

--- a/specstory-cli/pkg/monitor/supervisor.go
+++ b/specstory-cli/pkg/monitor/supervisor.go
@@ -1,0 +1,209 @@
+package monitor
+
+import (
+	"context"
+	"log/slog"
+	"os/exec"
+	"sync"
+	"syscall"
+	"time"
+)
+
+// shutdownGracePeriod is how long a child gets to exit after SIGTERM before it
+// is SIGKILLed. Orphaned watch children are the operational footgun of the
+// monitor, so termination always escalates rather than waiting forever.
+const shutdownGracePeriod = 5 * time.Second
+
+// child tracks one running `specstory watch` process.
+type child struct {
+	cmd          *exec.Cmd
+	lastActivity time.Time
+	// done is closed by the per-child Wait goroutine once the OS process has
+	// been reaped, so the supervisor can distinguish alive from exited without
+	// blocking, and terminators can wait for actual process death.
+	done chan struct{}
+}
+
+// exited reports (without blocking) whether the child's process has been reaped.
+func (c *child) exited() bool {
+	select {
+	case <-c.done:
+		return true
+	default:
+		return false
+	}
+}
+
+// Supervisor owns the table of running watch children: it spawns on activity,
+// reaps on idleness or self-exit, and terminates everything on shutdown.
+type Supervisor struct {
+	mu          sync.Mutex
+	children    map[string]*child
+	idleTimeout time.Duration
+
+	// spawn returns a STARTED command (SpawnWatch by default). Injectable so
+	// tests can launch a stub like /bin/sleep instead of real specstory.
+	spawn func(projectPath string) (*exec.Cmd, error)
+	// now is the clock (time.Now by default); injectable so idle-reaping tests
+	// don't have to actually wait out the timeout.
+	now func() time.Time
+}
+
+// NewSupervisor creates a Supervisor that reaps children idle for longer than
+// idleTimeout.
+func NewSupervisor(idleTimeout time.Duration) *Supervisor {
+	return &Supervisor{
+		children:    make(map[string]*child),
+		idleTimeout: idleTimeout,
+		spawn:       SpawnWatch,
+		now:         time.Now,
+	}
+}
+
+// NotifyActivity records activity for projectPath: it refreshes the idle clock
+// of a running child, respawns one that exited on its own, or spawns a new one.
+func (s *Supervisor) NotifyActivity(projectPath string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if c, ok := s.children[projectPath]; ok {
+		if !c.exited() {
+			c.lastActivity = s.now()
+			return
+		}
+		// The child died on its own (crash, external kill) but activity is
+		// back — drop the dead entry and respawn below.
+		delete(s.children, projectPath)
+		slog.Info("Monitor: child had exited; respawning on new activity", "project", projectPath)
+	}
+	s.spawnLocked(projectPath)
+}
+
+// spawnLocked starts a watch child and registers it. Caller must hold s.mu.
+// A spawn failure is logged, not fatal: the next activity event retries.
+func (s *Supervisor) spawnLocked(projectPath string) {
+	cmd, err := s.spawn(projectPath)
+	if err != nil {
+		slog.Error("Monitor: failed to spawn watch child", "project", projectPath, "error", err)
+		return
+	}
+
+	c := &child{cmd: cmd, lastActivity: s.now(), done: make(chan struct{})}
+	s.children[projectPath] = c
+
+	// Reap the OS process the moment it exits so it never lingers as a zombie;
+	// table cleanup happens later in reapOnce/NotifyActivity, which observe
+	// the closed done channel.
+	go func() {
+		_ = cmd.Wait()
+		close(c.done)
+		slog.Info("Monitor: watch child exited", "project", projectPath, "pid", cmd.Process.Pid)
+	}()
+
+	slog.Info("Monitor: spawned watch child", "project", projectPath, "pid", cmd.Process.Pid)
+}
+
+// Run drives the reap loop until ctx is cancelled. The tick interval is
+// min(30s, idleTimeout/2) so short timeouts are honored promptly without
+// busy-polling for long ones (floored at 1s to avoid spinning in extreme
+// configurations).
+func (s *Supervisor) Run(ctx context.Context) {
+	interval := 30 * time.Second
+	if half := s.idleTimeout / 2; half < interval {
+		interval = half
+	}
+	if interval < time.Second {
+		interval = time.Second
+	}
+
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			s.reapOnce()
+		}
+	}
+}
+
+// reapOnce removes children that exited on their own and SIGTERMs children
+// idle past the timeout. Termination happens off-lock and asynchronously: a
+// stuck child must not stall the supervisor, and the terminator escalates to
+// SIGKILL on its own.
+func (s *Supervisor) reapOnce() {
+	type reapTarget struct {
+		project string
+		c       *child
+	}
+	var idle []reapTarget
+
+	s.mu.Lock()
+	now := s.now()
+	for project, c := range s.children {
+		if c.exited() {
+			delete(s.children, project)
+			slog.Info("Monitor: reaped child that exited on its own", "project", project)
+			continue
+		}
+		if now.Sub(c.lastActivity) >= s.idleTimeout {
+			delete(s.children, project)
+			idle = append(idle, reapTarget{project, c})
+		}
+	}
+	s.mu.Unlock()
+
+	for _, t := range idle {
+		slog.Info("Monitor: reaping idle watch child", "project", t.project, "pid", t.c.cmd.Process.Pid, "idleTimeout", s.idleTimeout)
+		go terminateChild(t.c)
+	}
+}
+
+// Shutdown SIGTERMs ALL children in parallel and blocks until each has
+// actually exited (bounded by the SIGKILL escalation in terminateChild).
+// Robustness here is non-negotiable: children the monitor loses track of keep
+// running as orphaned watchers.
+func (s *Supervisor) Shutdown() {
+	s.mu.Lock()
+	children := s.children
+	s.children = make(map[string]*child)
+	s.mu.Unlock()
+
+	var wg sync.WaitGroup
+	for project, c := range children {
+		wg.Add(1)
+		go func(project string, c *child) {
+			defer wg.Done()
+			slog.Info("Monitor: shutting down watch child", "project", project, "pid", c.cmd.Process.Pid)
+			terminateChild(c)
+		}(project, c)
+	}
+	wg.Wait()
+	slog.Info("Monitor: all watch children shut down", "count", len(children))
+}
+
+// terminateChild asks a child to exit with SIGTERM (watch handles it
+// gracefully via signal.NotifyContext), escalating to SIGKILL after the grace
+// period. Blocks until the process is reaped; the post-SIGKILL wait is bounded
+// only as a last-resort guard against a kernel-stuck process.
+func terminateChild(c *child) {
+	// Signal errors (process already gone) are expected races, not failures;
+	// the done channel below is the source of truth.
+	_ = c.cmd.Process.Signal(syscall.SIGTERM)
+
+	select {
+	case <-c.done:
+	case <-time.After(shutdownGracePeriod):
+		slog.Warn("Monitor: watch child ignored SIGTERM, killing", "pid", c.cmd.Process.Pid)
+		_ = c.cmd.Process.Kill()
+		select {
+		case <-c.done:
+		case <-time.After(shutdownGracePeriod):
+			// SIGKILL is not survivable; reaching here means the process is
+			// stuck in the kernel. Nothing more we can do but say so.
+			slog.Error("Monitor: watch child did not exit after SIGKILL", "pid", c.cmd.Process.Pid)
+		}
+	}
+}

--- a/specstory-cli/pkg/monitor/supervisor_test.go
+++ b/specstory-cli/pkg/monitor/supervisor_test.go
@@ -1,0 +1,210 @@
+package monitor
+
+import (
+	"os/exec"
+	"sync"
+	"testing"
+	"time"
+)
+
+// fakeClock is an injectable clock so idle-reaping tests never have to
+// actually wait out the timeout.
+type fakeClock struct {
+	mu  sync.Mutex
+	now time.Time
+}
+
+func newFakeClock() *fakeClock {
+	return &fakeClock{now: time.Date(2026, 7, 15, 12, 0, 0, 0, time.UTC)}
+}
+
+func (c *fakeClock) Now() time.Time {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.now
+}
+
+func (c *fakeClock) Advance(d time.Duration) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.now = c.now.Add(d)
+}
+
+// spawnCounter is a spawn stub that launches a real (but harmless) child
+// process — sleep by default — instead of recursively spawning specstory.
+type spawnCounter struct {
+	mu    sync.Mutex
+	calls int
+	argv  []string
+}
+
+func newSpawnCounter(argv ...string) *spawnCounter {
+	if len(argv) == 0 {
+		argv = []string{"sleep", "60"}
+	}
+	return &spawnCounter{argv: argv}
+}
+
+func (sc *spawnCounter) spawn(projectPath string) (*exec.Cmd, error) {
+	sc.mu.Lock()
+	sc.calls++
+	sc.mu.Unlock()
+	// Match the SpawnWatch contract: return a STARTED command.
+	cmd := exec.Command(sc.argv[0], sc.argv[1:]...)
+	if err := cmd.Start(); err != nil {
+		return nil, err
+	}
+	return cmd, nil
+}
+
+func (sc *spawnCounter) count() int {
+	sc.mu.Lock()
+	defer sc.mu.Unlock()
+	return sc.calls
+}
+
+// newTestSupervisor wires a Supervisor with fake clock + spawn stub, and
+// guarantees no child outlives the test even on failure.
+func newTestSupervisor(t *testing.T, idleTimeout time.Duration, sc *spawnCounter) (*Supervisor, *fakeClock) {
+	t.Helper()
+	clock := newFakeClock()
+	s := NewSupervisor(idleTimeout)
+	s.now = clock.Now
+	s.spawn = sc.spawn
+	t.Cleanup(s.Shutdown)
+	return s, clock
+}
+
+// childFor returns the tracked child for projectPath, or nil.
+func (s *Supervisor) childFor(projectPath string) *child {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.children[projectPath]
+}
+
+func (s *Supervisor) childCount() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return len(s.children)
+}
+
+// waitForExit fails the test if the child's process hasn't been reaped within
+// a generous timeout.
+func waitForExit(t *testing.T, c *child, context string) {
+	t.Helper()
+	select {
+	case <-c.done:
+	case <-time.After(15 * time.Second):
+		t.Fatalf("%s: child pid %d did not exit", context, c.cmd.Process.Pid)
+	}
+	if c.cmd.ProcessState == nil {
+		t.Fatalf("%s: child done but never reaped (ProcessState nil)", context)
+	}
+}
+
+func TestSupervisor_SpawnRefreshAndNoDoubleSpawn(t *testing.T) {
+	sc := newSpawnCounter()
+	s, clock := newTestSupervisor(t, 5*time.Minute, sc)
+
+	s.NotifyActivity("/repo/a")
+	if got := sc.count(); got != 1 {
+		t.Fatalf("spawn count after first activity = %d, want 1", got)
+	}
+	c := s.childFor("/repo/a")
+	if c == nil {
+		t.Fatal("child not registered after NotifyActivity")
+	}
+	first := c.lastActivity
+
+	// Repeat activity must refresh the idle clock, not spawn a second child.
+	clock.Advance(1 * time.Minute)
+	s.NotifyActivity("/repo/a")
+	if got := sc.count(); got != 1 {
+		t.Errorf("spawn count after repeat activity = %d, want 1 (no double spawn)", got)
+	}
+	if got := s.childFor("/repo/a").lastActivity; !got.After(first) {
+		t.Errorf("lastActivity not refreshed: %v -> %v", first, got)
+	}
+}
+
+func TestSupervisor_ReapIdleAndRespawn(t *testing.T) {
+	sc := newSpawnCounter()
+	s, clock := newTestSupervisor(t, 5*time.Minute, sc)
+
+	s.NotifyActivity("/repo/a")
+	c := s.childFor("/repo/a")
+
+	// Not yet idle: nothing reaped.
+	clock.Advance(4 * time.Minute)
+	s.reapOnce()
+	if s.childFor("/repo/a") == nil {
+		t.Fatal("child reaped before idle timeout")
+	}
+
+	// Idle past the timeout: removed from the table and actually terminated.
+	clock.Advance(2 * time.Minute)
+	s.reapOnce()
+	if s.childFor("/repo/a") != nil {
+		t.Fatal("idle child still in table after reap")
+	}
+	waitForExit(t, c, "idle reap")
+
+	// New activity after the reap respawns.
+	s.NotifyActivity("/repo/a")
+	if got := sc.count(); got != 2 {
+		t.Errorf("spawn count after post-reap activity = %d, want 2", got)
+	}
+	if s.childFor("/repo/a") == nil {
+		t.Error("child not respawned after reap")
+	}
+}
+
+func TestSupervisor_ChildExitsOnItsOwn(t *testing.T) {
+	// "true" exits immediately, simulating a crashed/killed watch child.
+	sc := newSpawnCounter("true")
+	s, _ := newTestSupervisor(t, 5*time.Minute, sc)
+
+	s.NotifyActivity("/repo/a")
+	c := s.childFor("/repo/a")
+	if c == nil {
+		t.Fatal("child not registered")
+	}
+	waitForExit(t, c, "self-exit")
+
+	t.Run("reap loop clears exited child", func(t *testing.T) {
+		s.reapOnce()
+		if s.childFor("/repo/a") != nil {
+			t.Error("exited child still in table after reapOnce")
+		}
+	})
+
+	t.Run("activity respawns exited child", func(t *testing.T) {
+		s.NotifyActivity("/repo/a")
+		if got := sc.count(); got != 2 {
+			t.Errorf("spawn count = %d, want 2 (respawn after self-exit)", got)
+		}
+	})
+}
+
+func TestSupervisor_ShutdownKillsAll(t *testing.T) {
+	sc := newSpawnCounter()
+	s, _ := newTestSupervisor(t, 5*time.Minute, sc)
+
+	s.NotifyActivity("/repo/a")
+	s.NotifyActivity("/repo/b")
+	childA := s.childFor("/repo/a")
+	childB := s.childFor("/repo/b")
+	if childA == nil || childB == nil {
+		t.Fatal("children not registered")
+	}
+
+	s.Shutdown()
+
+	// Shutdown must not return before every child is actually gone: orphaned
+	// watchers are the whole reason this method exists.
+	waitForExit(t, childA, "shutdown child a")
+	waitForExit(t, childB, "shutdown child b")
+	if got := s.childCount(); got != 0 {
+		t.Errorf("children in table after Shutdown = %d, want 0", got)
+	}
+}

--- a/specstory-cli/pkg/providers/claudecode/path_utils.go
+++ b/specstory-cli/pkg/providers/claudecode/path_utils.go
@@ -25,6 +25,22 @@ func encodeProjectDirName(realPath string) string {
 	return name
 }
 
+// EncodeProjectDirName exposes Claude Code's project-directory naming for a
+// project path. Claude Code's encoding is lossy (every non-alphanumeric/dash
+// character becomes a dash), so entries under ~/.claude/projects cannot be
+// decoded back to paths — callers that need to map an entry back to a project
+// (e.g. the monitor's activity resolver) must instead encode their known
+// project paths with this function and compare. Symlinks are resolved first
+// because Claude Code encodes the real path; if resolution fails (path does
+// not exist yet) the raw path is used, matching resolveClaudeProjectDir.
+func EncodeProjectDirName(projectPath string) string {
+	realPath, err := filepath.EvalSymlinks(projectPath)
+	if err != nil {
+		realPath = projectPath
+	}
+	return encodeProjectDirName(realPath)
+}
+
 // resolveClaudeProjectDir returns ~/.claude/projects/<encoded> for the given
 // project path, resolving symlinks, WITHOUT requiring the directory to exist.
 // Used when writing a reconstructed session into the store (the caller creates

--- a/specstory-cli/pkg/providers/codexcli/path_utils.go
+++ b/specstory-cli/pkg/providers/codexcli/path_utils.go
@@ -17,6 +17,29 @@ func codexSessionsRoot(homeDir string) string {
 	return filepath.Join(homeDir, ".codex", "sessions")
 }
 
+// SessionsRoot returns the directory Codex CLI stores session files under,
+// honoring CODEX_HOME the same way session enumeration does. Exposed so the
+// monitor command can watch the same storage root this provider reads from.
+func SessionsRoot() (string, error) {
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	return codexSessionsRoot(homeDir), nil
+}
+
+// SessionOriginCwd returns the originating working directory recorded in a
+// Codex session file's session_meta header (its first JSONL line). Exposed so
+// the monitor's activity resolver can map a new session file back to a project
+// directory without re-implementing Codex's session-meta parsing.
+func SessionOriginCwd(sessionPath string) (string, error) {
+	meta, err := loadCodexSessionMeta(sessionPath)
+	if err != nil {
+		return "", err
+	}
+	return meta.Payload.CWD, nil
+}
+
 // normalizeCodexPath resolves a path to an absolute, cleaned representation suitable for comparisons.
 func normalizeCodexPath(path string) string {
 	if strings.TrimSpace(path) == "" {


### PR DESCRIPTION
## What this adds

A new `specstory monitor <root-dir>` command — a source-tree supervisor. It:

- discovers every git repo under a root directory (depth/exclusions tunable via `--max-depth` / `--exclude`),
- watches the coding agents' own session storage (**Claude Code, Codex CLI, Cursor CLI**) for activity,
- maps that activity back to the owning repo, and
- supervises a per-repo `specstory watch` child — spawning it on activity and stopping it after a configurable idle timeout (`--idle-timeout`, default 5m).

Defaults are configurable via a new `[monitor]` section in `config.toml`. Supervised captures are redacted by the same mechanism as any `specstory watch` (the child follows the user's redaction config), so no redaction logic lives in the supervisor.

## VS Code Copilot IDE detection is included but **build-gated** (off by default)

The monitor can also watch VS Code Copilot IDE workspace storage and map it to repos. That code depends on the `copilotide` provider, which is **not yet in `dev`** (it lives on the `copilot-ide` branch). To keep this PR mergeable and CI-green now, all Copilot-IDE-specific code is compiled only under the `copilotide_monitor` build tag:

- **Default build (what CI runs): excludes it entirely.** `go build ./...` / `go vet` / `go test` are green, and `go list -deps ./...` pulls in **no** `copilotide` package. The default `monitor` help/error text advertises only Claude Code / Codex CLI / Cursor CLI.
- Gated files: `pkg/monitor/copilotwatch.go` (+ its test), `pkg/monitor/activity_copilotide.go`, `pkg/cmd/monitor_copilotide.go`; matching no-op stubs (`*_stub.go`) satisfy the default build.

### Enabling it once `copilot-ide` lands

Enabling the Copilot path requires **three** things, not just flipping the tag:

1. the `copilotide` provider present in `dev` (i.e. `copilot-ide` merged);
2. four small exported accessors on that provider that the monitor uses — `Variants`, `ReadWorkspaceJSON`, `URIToPath`, `CollectCodeWorkspaceFolders` (thin wrappers I can contribute alongside, when copilot-ide merges);
3. removing the `//go:build copilotide_monitor` tag (or defaulting it on).

I verified the gated build compiles cleanly against a provider that has these accessors.

## Supporting additive accessors

To let the monitor's activity resolver reuse existing provider logic instead of re-implementing it, this PR exposes three thin wrappers around already-present unexported functions (additive only, no behavior change):

- `codexcli.SessionsRoot()`, `codexcli.SessionOriginCwd()`
- `claudecode.EncodeProjectDirName()`
- a new `analytics.EventMonitorActivated` event constant

## Testing

- Default build, `go vet`, and `go test ./...` all pass (monitor package has unit tests for discovery, root watching, the supervisor lifecycle — spawn/idle-stop/restart/clean-shutdown — and child exec).
- The gated (`-tags copilotide_monitor`) build was verified to compile against the copilotide provider.

## Notes

- Targets `dev`.
- Contains no redaction code — secret redaction already ships in `dev` via the Betterleaks `pkg/redact` package; the monitor simply relies on the child `watch` doing it.
