### PR TITLE
fix(copilotide): read sessions from all matching workspaces (+ monitor accessors)

### DIFF
--- a/specstory-cli/pkg/providers/copilotide/agent_session_test.go
+++ b/specstory-cli/pkg/providers/copilotide/agent_session_test.go
@@ -1,0 +1,373 @@
+package copilotide
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/specstoryai/getspecstory/specstory-cli/pkg/spi/schema"
+)
+
+// TestConvertToSessionData_Basic verifies the top-level conversion: variant identity,
+// session metadata, workspace root threading, exchange construction, and that RawData
+// round-trips as valid JSON carrying the original session.
+func TestConvertToSessionData_Basic(t *testing.T) {
+	composer := VSCodeComposer{
+		Host:            "vscode",
+		SessionID:       "sess-1",
+		CustomTitle:     "Fix the loader",
+		Version:         3,
+		CreationDate:    1700000000000,
+		LastMessageDate: 1700000600000,
+		Requests: []VSCodeRequestBlock{
+			{
+				RequestID: "r-1",
+				Timestamp: 1700000100000,
+				Message:   VSCodeMessage{Text: "Please fix the loader"},
+				Result: VSCodeResult{
+					Metadata: VSCodeResultMetadata{
+						Messages: []VSCodeMetadataMessage{
+							{Role: "assistant", Content: "Fixed it."},
+						},
+					},
+				},
+				ModelID: "gpt-5",
+			},
+		},
+	}
+
+	p := NewProvider(VSCode)
+	session := p.ConvertToSessionData(composer, "/Users/me/proj", nil)
+
+	if session.SessionID != "sess-1" {
+		t.Errorf("SessionID = %q, want %q", session.SessionID, "sess-1")
+	}
+	if session.Slug != "fix-the-loader" {
+		t.Errorf("Slug = %q, want %q", session.Slug, "fix-the-loader")
+	}
+	if session.SessionData.Provider.ID != "copilotide" {
+		t.Errorf("Provider.ID = %q, want %q", session.SessionData.Provider.ID, "copilotide")
+	}
+	if session.SessionData.WorkspaceRoot != "/Users/me/proj" {
+		t.Errorf("WorkspaceRoot = %q, want %q", session.SessionData.WorkspaceRoot, "/Users/me/proj")
+	}
+	if session.CreatedAt == "" || session.SessionData.UpdatedAt == "" {
+		t.Errorf("timestamps must be populated: created=%q updated=%q",
+			session.CreatedAt, session.SessionData.UpdatedAt)
+	}
+
+	if len(session.SessionData.Exchanges) != 1 {
+		t.Fatalf("len(Exchanges) = %d, want 1", len(session.SessionData.Exchanges))
+	}
+	exchange := session.SessionData.Exchanges[0]
+	if exchange.ExchangeID != "r-1" {
+		t.Errorf("ExchangeID = %q, want %q", exchange.ExchangeID, "r-1")
+	}
+	if len(exchange.Messages) != 2 {
+		t.Fatalf("len(Messages) = %d, want 2 (user + agent)", len(exchange.Messages))
+	}
+	if exchange.Messages[0].Role != schema.RoleUser {
+		t.Errorf("Messages[0].Role = %q, want %q", exchange.Messages[0].Role, schema.RoleUser)
+	}
+	if exchange.Messages[1].Role != schema.RoleAgent {
+		t.Errorf("Messages[1].Role = %q, want %q", exchange.Messages[1].Role, schema.RoleAgent)
+	}
+	if got := exchange.Messages[1].Content[0].Text; got != "Fixed it." {
+		t.Errorf("agent text = %q, want %q", got, "Fixed it.")
+	}
+
+	// RawData must be valid JSON preserving the original session.
+	var raw VSCodeComposer
+	if err := json.Unmarshal([]byte(session.RawData), &raw); err != nil {
+		t.Fatalf("RawData is not valid JSON: %v", err)
+	}
+	if raw.SessionID != "sess-1" {
+		t.Errorf("RawData SessionID = %q, want %q", raw.SessionID, "sess-1")
+	}
+}
+
+// TestConvertToSessionData_EmptySession verifies an empty session (no requests, no
+// state) converts without exchanges rather than failing.
+func TestConvertToSessionData_EmptySession(t *testing.T) {
+	p := NewProvider(VSCode)
+	session := p.ConvertToSessionData(VSCodeComposer{SessionID: "empty-1"}, "/proj", nil)
+
+	if session.SessionID != "empty-1" {
+		t.Errorf("SessionID = %q, want %q", session.SessionID, "empty-1")
+	}
+	if len(session.SessionData.Exchanges) != 0 {
+		t.Errorf("expected no exchanges, got %d", len(session.SessionData.Exchanges))
+	}
+	if session.Slug != "untitled" {
+		t.Errorf("Slug = %q, want %q for empty session", session.Slug, "untitled")
+	}
+}
+
+// TestConvertToSessionData_SyntheticFromEditingState verifies editing-only sessions
+// (no chat requests but a state file with file operations) produce a synthetic
+// exchange describing the operations.
+func TestConvertToSessionData_SyntheticFromEditingState(t *testing.T) {
+	tests := []struct {
+		name          string
+		state         *VSCodeStateFile
+		wantExchanges int
+		wantAgentHas  []string
+	}{
+		{
+			name: "v2 timeline operations summarized",
+			state: &VSCodeStateFile{
+				Version:   2,
+				SessionID: "edit-1",
+				Timeline: &VSCodeTimeline{
+					Operations: []VSCodeOperation{
+						{Type: "create", URI: &VSCodeUri{FSPath: "/proj/new.go"}},
+						{Type: "textEdit", URI: &VSCodeUri{Path: "/proj/main.go"}, Edits: []any{"e1", "e2"}},
+						{Type: "delete", URI: &VSCodeUri{FSPath: "/proj/old.go"}},
+					},
+				},
+			},
+			wantExchanges: 1,
+			wantAgentHas: []string{
+				"Created file: `new.go`",
+				"Edited `main.go` (2 edits)",
+				"Deleted file: `old.go`",
+			},
+		},
+		{
+			name: "v1 snapshot entries summarized",
+			state: &VSCodeStateFile{
+				Version:   1,
+				SessionID: "edit-2",
+				RecentSnapshot: map[string]any{
+					"entries": []any{
+						map[string]any{"resource": "file:///proj/util.go"},
+					},
+				},
+			},
+			wantExchanges: 1,
+			wantAgentHas:  []string{"Modified `util.go`"},
+		},
+		{
+			name:          "state without editing activity yields no exchanges",
+			state:         &VSCodeStateFile{Version: 2, SessionID: "edit-3"},
+			wantExchanges: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			composer := VSCodeComposer{
+				SessionID:    "edit-session",
+				CustomTitle:  "Editing pass",
+				CreationDate: 1700000000000,
+			}
+			p := NewProvider(VSCode)
+			session := p.ConvertToSessionData(composer, "/proj", tt.state)
+
+			if len(session.SessionData.Exchanges) != tt.wantExchanges {
+				t.Fatalf("len(Exchanges) = %d, want %d",
+					len(session.SessionData.Exchanges), tt.wantExchanges)
+			}
+			if tt.wantExchanges == 0 {
+				return
+			}
+
+			messages := session.SessionData.Exchanges[0].Messages
+			if len(messages) < 2 {
+				t.Fatalf("expected user + agent messages, got %d", len(messages))
+			}
+			if got := messages[0].Content[0].Text; got != "Editing pass" {
+				t.Errorf("synthetic user text = %q, want the custom title", got)
+			}
+			agentText := messages[len(messages)-1].Content[0].Text
+			for _, want := range tt.wantAgentHas {
+				if !strings.Contains(agentText, want) {
+					t.Errorf("agent text missing %q:\n%s", want, agentText)
+				}
+			}
+		})
+	}
+}
+
+// TestConvertRequestToMessages covers the per-request message assembly: user message
+// always present, thinking only alongside real tool calls, tool messages built from
+// the response array, and the final-text fallback chain (metadata messages ->
+// toolCallRounds response -> response array values).
+func TestConvertRequestToMessages(t *testing.T) {
+	tests := []struct {
+		name      string
+		req       VSCodeRequestBlock
+		wantRoles []string // in order; "user"/"agent"
+		wantTexts []string // substring expected somewhere in the messages' text parts
+		wantTool  string   // tool name expected on exactly one message, "" for none
+	}{
+		{
+			name: "final text from metadata messages",
+			req: VSCodeRequestBlock{
+				RequestID: "r-1",
+				Message:   VSCodeMessage{Text: "hello"},
+				Result: VSCodeResult{Metadata: VSCodeResultMetadata{
+					Messages: []VSCodeMetadataMessage{{Role: "assistant", Content: "hi there"}},
+				}},
+			},
+			wantRoles: []string{schema.RoleUser, schema.RoleAgent},
+			wantTexts: []string{"hello", "hi there"},
+		},
+		{
+			name: "no tool calls: toolCallRounds response becomes the final text without thinking",
+			req: VSCodeRequestBlock{
+				RequestID: "r-2",
+				Message:   VSCodeMessage{Text: "explain"},
+				Result: VSCodeResult{Metadata: VSCodeResultMetadata{
+					ToolCallRounds: []VSCodeToolCallRound{{Response: "the explanation"}},
+				}},
+			},
+			wantRoles: []string{schema.RoleUser, schema.RoleAgent},
+			wantTexts: []string{"explain", "the explanation"},
+		},
+		{
+			name: "tool calls: thinking, tool message, and response-array final text",
+			req: VSCodeRequestBlock{
+				RequestID: "r-3",
+				Message:   VSCodeMessage{Text: "create the file"},
+				Response: rawMessages(
+					`{"kind":"toolInvocationSerialized","toolCallId":"vs-1"}`,
+					`{"value":"File created."}`,
+				),
+				Result: VSCodeResult{Metadata: VSCodeResultMetadata{
+					ToolCallRounds: []VSCodeToolCallRound{{
+						Response: "I will create the file now",
+						ToolCalls: []VSCodeToolCallInfo{
+							{ID: "call-1", Name: "create_file", Arguments: `{"filePath":"/proj/a.go"}`},
+						},
+					}},
+				}},
+				ModelID: "gpt-5",
+			},
+			wantRoles: []string{schema.RoleUser, schema.RoleAgent, schema.RoleAgent, schema.RoleAgent},
+			wantTexts: []string{"create the file", "I will create the file now", "File created."},
+			wantTool:  "create_file",
+		},
+		{
+			name: "nothing but the user message",
+			req: VSCodeRequestBlock{
+				RequestID: "r-4",
+				Message:   VSCodeMessage{Text: ""},
+			},
+			wantRoles: []string{schema.RoleUser},
+		},
+		{
+			name: "malformed response entries are skipped without dropping the rest",
+			req: VSCodeRequestBlock{
+				RequestID: "r-5",
+				Message:   VSCodeMessage{Text: "robust"},
+				Response: rawMessages(
+					`not json at all`,
+					`{"value":"still extracted"}`,
+				),
+			},
+			wantRoles: []string{schema.RoleUser, schema.RoleAgent},
+			wantTexts: []string{"robust", "still extracted"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			messages := ConvertRequestToMessages(tt.req)
+
+			if len(messages) != len(tt.wantRoles) {
+				t.Fatalf("len(messages) = %d, want %d: %+v", len(messages), len(tt.wantRoles), messages)
+			}
+			for i, wantRole := range tt.wantRoles {
+				if messages[i].Role != wantRole {
+					t.Errorf("messages[%d].Role = %q, want %q", i, messages[i].Role, wantRole)
+				}
+			}
+
+			// Collect all text parts across messages for substring checks.
+			var allText strings.Builder
+			var toolName string
+			for _, msg := range messages {
+				for _, part := range msg.Content {
+					allText.WriteString(part.Text)
+					allText.WriteString("\n")
+				}
+				if msg.Tool != nil {
+					toolName = msg.Tool.Name
+				}
+			}
+			for _, want := range tt.wantTexts {
+				if !strings.Contains(allText.String(), want) {
+					t.Errorf("messages missing text %q in:\n%s", want, allText.String())
+				}
+			}
+			if toolName != tt.wantTool {
+				t.Errorf("tool name = %q, want %q", toolName, tt.wantTool)
+			}
+		})
+	}
+}
+
+// TestConvertRequestToMessages_ThinkingPart verifies thinking is emitted as a
+// dedicated ContentTypeThinking part carrying the model ID, not as plain text.
+func TestConvertRequestToMessages_ThinkingPart(t *testing.T) {
+	req := VSCodeRequestBlock{
+		RequestID: "r-think",
+		Message:   VSCodeMessage{Text: "do it"},
+		Response: rawMessages(
+			`{"kind":"toolInvocationSerialized","toolCallId":"vs-1"}`,
+		),
+		Result: VSCodeResult{Metadata: VSCodeResultMetadata{
+			ToolCallRounds: []VSCodeToolCallRound{{
+				Response:  "reasoning first",
+				ToolCalls: []VSCodeToolCallInfo{{ID: "call-1", Name: "read_file"}},
+			}},
+		}},
+		ModelID: "gpt-5",
+	}
+
+	messages := ConvertRequestToMessages(req)
+	if len(messages) < 2 {
+		t.Fatalf("expected at least user + thinking messages, got %d", len(messages))
+	}
+
+	thinking := messages[1]
+	if thinking.Role != schema.RoleAgent {
+		t.Errorf("thinking message role = %q, want %q", thinking.Role, schema.RoleAgent)
+	}
+	if thinking.Model != "gpt-5" {
+		t.Errorf("thinking message model = %q, want %q", thinking.Model, "gpt-5")
+	}
+	if len(thinking.Content) != 1 || thinking.Content[0].Type != schema.ContentTypeThinking {
+		t.Fatalf("expected one %q content part, got %+v", schema.ContentTypeThinking, thinking.Content)
+	}
+	if thinking.Content[0].Text != "reasoning first" {
+		t.Errorf("thinking text = %q, want %q", thinking.Content[0].Text, "reasoning first")
+	}
+}
+
+// TestMapToolType verifies the VS Code tool name -> schema tool type mapping,
+// including the MCP prefix rule and the generic fallback for unknown names.
+func TestMapToolType(t *testing.T) {
+	tests := []struct {
+		name     string
+		toolName string
+		want     string
+	}{
+		{"read tool", "read_file", schema.ToolTypeRead},
+		{"write tool", "create_file", schema.ToolTypeWrite},
+		{"search tool", "grep_search", schema.ToolTypeSearch},
+		{"shell tool", "bash", schema.ToolTypeShell},
+		{"task tool", "manage_todo_list", schema.ToolTypeTask},
+		{"mcp tool maps to generic", "mcp_github_create_issue", schema.ToolTypeGeneric},
+		{"unknown tool maps to generic", "never_heard_of_it", schema.ToolTypeGeneric},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := MapToolType(tt.toolName); got != tt.want {
+				t.Errorf("MapToolType(%q) = %q, want %q", tt.toolName, got, tt.want)
+			}
+		})
+	}
+}

--- a/specstory-cli/pkg/providers/copilotide/loader.go
+++ b/specstory-cli/pkg/providers/copilotide/loader.go
@@ -2,12 +2,19 @@ package copilotide
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"os"
 	"path/filepath"
 	"strings"
 )
+
+// ErrSessionNotFound reports that no session file exists for the requested ID in a
+// workspace. It is a sentinel so callers probing multiple matching workspaces can
+// distinguish "not in this workspace, try the next" from a real load failure that
+// should be surfaced immediately.
+var ErrSessionNotFound = errors.New("session not found")
 
 // LoadAllSessionFiles returns paths to all session JSON files in the workspace
 func LoadAllSessionFiles(workspaceDir string) ([]string, error) {
@@ -89,7 +96,7 @@ func LoadSessionByID(workspaceDir, sessionID string) (*VSCodeComposer, error) {
 	} else if _, err := os.Stat(jsonPath); err == nil {
 		sessionPath = jsonPath
 	} else {
-		return nil, fmt.Errorf("session not found: %s", sessionID)
+		return nil, fmt.Errorf("%w: %s", ErrSessionNotFound, sessionID)
 	}
 
 	return LoadSessionFile(sessionPath)

--- a/specstory-cli/pkg/providers/copilotide/loader_test.go
+++ b/specstory-cli/pkg/providers/copilotide/loader_test.go
@@ -1,0 +1,369 @@
+package copilotide
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// makeChatSessionsDir creates a workspace dir with a chatSessions subdirectory and
+// returns both paths.
+func makeChatSessionsDir(t *testing.T) (workspaceDir, chatSessionsDir string) {
+	t.Helper()
+
+	workspaceDir = t.TempDir()
+	chatSessionsDir = GetChatSessionsPath(workspaceDir)
+	if err := os.MkdirAll(chatSessionsDir, 0755); err != nil {
+		t.Fatalf("failed to create chatSessions dir: %v", err)
+	}
+	return workspaceDir, chatSessionsDir
+}
+
+// writeSessionFixture writes a session file with the given name and content into the
+// chatSessions dir and returns its full path.
+func writeSessionFixture(t *testing.T, chatSessionsDir, name, content string) string {
+	t.Helper()
+
+	path := filepath.Join(chatSessionsDir, name)
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatalf("failed to write session fixture %s: %v", name, err)
+	}
+	return path
+}
+
+func TestLoadSessionFile_JSON(t *testing.T) {
+	_, chatSessions := makeChatSessionsDir(t)
+	path := writeSessionFixture(t, chatSessions, "sess-json.json",
+		`{"sessionId":"sess-json","version":3,"requesterUsername":"user",`+
+			`"requests":[{"requestId":"r-1","message":{"text":"hello"}}]}`)
+
+	composer, err := LoadSessionFile(path)
+	if err != nil {
+		t.Fatalf("LoadSessionFile() error = %v", err)
+	}
+	if composer.SessionID != "sess-json" {
+		t.Errorf("SessionID = %q, want %q", composer.SessionID, "sess-json")
+	}
+	if len(composer.Requests) != 1 || composer.Requests[0].Message.Text != "hello" {
+		t.Errorf("Requests = %+v, want one request with text %q", composer.Requests, "hello")
+	}
+}
+
+func TestLoadSessionFile_JSONL(t *testing.T) {
+	_, chatSessions := makeChatSessionsDir(t)
+	lines := []string{
+		`{"kind":0,"v":{"sessionId":"sess-jsonl","version":3,"requests":[]}}`,
+		`{"kind":2,"k":["requests"],"v":[{"requestId":"r-1","message":{"text":"first"}}]}`,
+		`{"kind":1,"k":["customTitle"],"v":"Streamed Session"}`,
+	}
+	path := writeSessionFixture(t, chatSessions, "sess-jsonl.jsonl", strings.Join(lines, "\n"))
+
+	composer, err := LoadSessionFile(path)
+	if err != nil {
+		t.Fatalf("LoadSessionFile() error = %v", err)
+	}
+	if composer.SessionID != "sess-jsonl" {
+		t.Errorf("SessionID = %q, want %q", composer.SessionID, "sess-jsonl")
+	}
+	if composer.CustomTitle != "Streamed Session" {
+		t.Errorf("CustomTitle = %q, want %q", composer.CustomTitle, "Streamed Session")
+	}
+	if len(composer.Requests) != 1 || composer.Requests[0].Message.Text != "first" {
+		t.Errorf("Requests = %+v, want one request with text %q", composer.Requests, "first")
+	}
+}
+
+// TestLoadSessionFile_StreamedResponseGrowth simulates VS Code streaming a response:
+// the file is rewritten with the SAME request count but the in-progress response text
+// grown in place (a new kind:1 line replaces the request's response array with a
+// longer one). A reload must reflect the grown text — this is the scenario that
+// motivated fingerprint-based dedup in pkg/utils/watch_agents.go, where message-count
+// heuristics alone would treat the grown file as unchanged.
+func TestLoadSessionFile_StreamedResponseGrowth(t *testing.T) {
+	_, chatSessions := makeChatSessionsDir(t)
+
+	initial := `{"kind":0,"v":{"sessionId":"sess-grow","version":3,` +
+		`"requests":[{"requestId":"r-1","message":{"text":"write the docs"},` +
+		`"response":[{"value":"Partial"}]}]}}`
+	path := writeSessionFixture(t, chatSessions, "sess-grow.jsonl", initial)
+
+	composer, err := LoadSessionFile(path)
+	if err != nil {
+		t.Fatalf("initial LoadSessionFile() error = %v", err)
+	}
+	if len(composer.Requests) != 1 {
+		t.Fatalf("initial len(Requests) = %d, want 1", len(composer.Requests))
+	}
+	initialText := ExtractTextFromResponseArray(composer.Requests[0].Response)
+	if initialText != "Partial" {
+		t.Fatalf("initial response text = %q, want %q", initialText, "Partial")
+	}
+
+	// Rewrite: VS Code appends an update line that replaces the streaming request's
+	// response with a longer version. Message/request count stays identical.
+	grown := initial + "\n" +
+		`{"kind":1,"k":["requests",0,"response"],"v":[{"value":"Partial answer, now complete with more text."}]}`
+	if err := os.WriteFile(path, []byte(grown), 0644); err != nil {
+		t.Fatalf("failed to rewrite session fixture: %v", err)
+	}
+
+	composer, err = LoadSessionFile(path)
+	if err != nil {
+		t.Fatalf("reload LoadSessionFile() error = %v", err)
+	}
+	if len(composer.Requests) != 1 {
+		t.Fatalf("reload len(Requests) = %d, want 1 (same message count)", len(composer.Requests))
+	}
+	grownText := ExtractTextFromResponseArray(composer.Requests[0].Response)
+	if grownText != "Partial answer, now complete with more text." {
+		t.Errorf("grown response text = %q, want the extended text", grownText)
+	}
+	if len(grownText) <= len(initialText) {
+		t.Errorf("reloaded text did not grow: initial %d chars, reloaded %d chars",
+			len(initialText), len(grownText))
+	}
+}
+
+// TestLoadSessionFile_MalformedUpdateLineSkipped verifies a corrupt line in the middle
+// of a JSONL session (e.g. a torn write) doesn't fail the load or drop later updates.
+func TestLoadSessionFile_MalformedUpdateLineSkipped(t *testing.T) {
+	_, chatSessions := makeChatSessionsDir(t)
+	lines := []string{
+		`{"kind":0,"v":{"sessionId":"sess-torn","version":3,"requests":[]}}`,
+		`{"kind":2,"k":["requests"],"v":[{"requestId":"r-1","message":{"text":"first"}}]`, // torn: missing closing brace
+		`{"kind":1,"k":["customTitle"],"v":"Survived"}`,
+	}
+	path := writeSessionFixture(t, chatSessions, "sess-torn.jsonl", strings.Join(lines, "\n"))
+
+	composer, err := LoadSessionFile(path)
+	if err != nil {
+		t.Fatalf("LoadSessionFile() error = %v", err)
+	}
+	if composer.CustomTitle != "Survived" {
+		t.Errorf("CustomTitle = %q, want %q (update after torn line must apply)",
+			composer.CustomTitle, "Survived")
+	}
+	if len(composer.Requests) != 0 {
+		t.Errorf("len(Requests) = %d, want 0 (torn append must be dropped)", len(composer.Requests))
+	}
+}
+
+func TestLoadSessionFile_Errors(t *testing.T) {
+	_, chatSessions := makeChatSessionsDir(t)
+
+	tests := []struct {
+		name            string
+		fileName        string
+		content         string // ignored when missing is true
+		missing         bool
+		wantErrContains string
+	}{
+		{
+			name:            "missing file",
+			fileName:        "does-not-exist.json",
+			missing:         true,
+			wantErrContains: "failed to read session file",
+		},
+		{
+			name:            "empty JSONL file",
+			fileName:        "empty.jsonl",
+			content:         "\n\n",
+			wantErrContains: "empty JSONL file",
+		},
+		{
+			name:            "malformed first JSONL line",
+			fileName:        "bad-first.jsonl",
+			content:         `this is not json`,
+			wantErrContains: "failed to parse first JSONL line",
+		},
+		{
+			name:            "first JSONL line is not kind 0",
+			fileName:        "wrong-kind.jsonl",
+			content:         `{"kind":1,"k":["customTitle"],"v":"oops"}`,
+			wantErrContains: "expected kind:0",
+		},
+		{
+			name:            "malformed JSON file",
+			fileName:        "bad.json",
+			content:         `{"sessionId": `,
+			wantErrContains: "failed to parse session JSON",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			path := filepath.Join(chatSessions, tt.fileName)
+			if !tt.missing {
+				path = writeSessionFixture(t, chatSessions, tt.fileName, tt.content)
+			}
+
+			_, err := LoadSessionFile(path)
+			if err == nil {
+				t.Fatalf("expected error containing %q, got nil", tt.wantErrContains)
+			}
+			if !strings.Contains(err.Error(), tt.wantErrContains) {
+				t.Errorf("error = %q, want it to contain %q", err.Error(), tt.wantErrContains)
+			}
+		})
+	}
+}
+
+func TestLoadAllSessionFiles(t *testing.T) {
+	workspaceDir, chatSessions := makeChatSessionsDir(t)
+
+	writeSessionFixture(t, chatSessions, "a.json", `{}`)
+	writeSessionFixture(t, chatSessions, "b.jsonl", `{}`)
+	writeSessionFixture(t, chatSessions, "notes.txt", `ignore me`)
+	if err := os.Mkdir(filepath.Join(chatSessions, "subdir.json"), 0755); err != nil {
+		t.Fatalf("failed to create decoy subdir: %v", err)
+	}
+
+	files, err := LoadAllSessionFiles(workspaceDir)
+	if err != nil {
+		t.Fatalf("LoadAllSessionFiles() error = %v", err)
+	}
+	if len(files) != 2 {
+		t.Fatalf("len(files) = %d, want 2 (json + jsonl only): %v", len(files), files)
+	}
+	for _, f := range files {
+		base := filepath.Base(f)
+		if base != "a.json" && base != "b.jsonl" {
+			t.Errorf("unexpected session file %q", f)
+		}
+	}
+}
+
+func TestLoadAllSessionFiles_MissingDir(t *testing.T) {
+	// Workspace dir exists but has no chatSessions subdirectory.
+	_, err := LoadAllSessionFiles(t.TempDir())
+	if err == nil {
+		t.Fatal("expected error for missing chatSessions directory, got nil")
+	}
+	if !strings.Contains(err.Error(), "chatSessions directory not found") {
+		t.Errorf("error = %q, want it to mention the missing chatSessions directory", err.Error())
+	}
+}
+
+func TestLoadSessionByID(t *testing.T) {
+	workspaceDir, chatSessions := makeChatSessionsDir(t)
+
+	// Session with both formats present: .jsonl must win (newer format).
+	writeSessionFixture(t, chatSessions, "dual.jsonl",
+		`{"kind":0,"v":{"sessionId":"from-jsonl","version":3}}`)
+	writeSessionFixture(t, chatSessions, "dual.json", `{"sessionId":"from-json"}`)
+
+	// Session with only the older .json format.
+	writeSessionFixture(t, chatSessions, "legacy.json", `{"sessionId":"legacy-json"}`)
+
+	tests := []struct {
+		name            string
+		sessionID       string
+		wantSessionID   string
+		wantErrContains string
+	}{
+		{
+			name:          "jsonl preferred over json",
+			sessionID:     "dual",
+			wantSessionID: "from-jsonl",
+		},
+		{
+			name:          "json fallback when no jsonl",
+			sessionID:     "legacy",
+			wantSessionID: "legacy-json",
+		},
+		{
+			name:            "unknown session id",
+			sessionID:       "nope",
+			wantErrContains: "session not found",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			composer, err := LoadSessionByID(workspaceDir, tt.sessionID)
+
+			if tt.wantErrContains != "" {
+				if err == nil {
+					t.Fatalf("expected error containing %q, got nil", tt.wantErrContains)
+				}
+				if !strings.Contains(err.Error(), tt.wantErrContains) {
+					t.Errorf("error = %q, want it to contain %q", err.Error(), tt.wantErrContains)
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if composer.SessionID != tt.wantSessionID {
+				t.Errorf("SessionID = %q, want %q", composer.SessionID, tt.wantSessionID)
+			}
+		})
+	}
+}
+
+// TestLoadStateFile verifies the optional-state contract: a valid file parses, while
+// a missing or malformed file yields (nil, nil) rather than an error, because state
+// only enriches a session and must never block loading it.
+func TestLoadStateFile(t *testing.T) {
+	tests := []struct {
+		name      string
+		content   string // empty means don't create the file
+		wantState bool
+	}{
+		{
+			name:      "valid state file",
+			content:   `{"version":2,"sessionId":"s-1","timeline":{"operations":[{"type":"create","uri":{"fsPath":"/proj/a.go"}}]}}`,
+			wantState: true,
+		},
+		{
+			name:      "missing state file returns nil without error",
+			wantState: false,
+		},
+		{
+			name:      "malformed state file returns nil without error",
+			content:   `{"version": `,
+			wantState: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			workspaceDir := t.TempDir()
+			const sessionID = "s-1"
+
+			if tt.content != "" {
+				statePath := GetStateFilePath(workspaceDir, sessionID)
+				if err := os.MkdirAll(filepath.Dir(statePath), 0755); err != nil {
+					t.Fatalf("failed to create state dir: %v", err)
+				}
+				if err := os.WriteFile(statePath, []byte(tt.content), 0644); err != nil {
+					t.Fatalf("failed to write state file: %v", err)
+				}
+			}
+
+			state, err := LoadStateFile(workspaceDir, sessionID)
+			if err != nil {
+				t.Fatalf("LoadStateFile() error = %v (state is optional, must never error)", err)
+			}
+
+			if !tt.wantState {
+				if state != nil {
+					t.Errorf("expected nil state, got %+v", state)
+				}
+				return
+			}
+
+			if state == nil {
+				t.Fatal("expected parsed state, got nil")
+			}
+			if state.Version != 2 || state.SessionID != "s-1" {
+				t.Errorf("state = %+v, want version 2 session s-1", state)
+			}
+			if state.Timeline == nil || len(state.Timeline.Operations) != 1 {
+				t.Errorf("state.Timeline = %+v, want one operation", state.Timeline)
+			}
+		})
+	}
+}

--- a/specstory-cli/pkg/providers/copilotide/provider.go
+++ b/specstory-cli/pkg/providers/copilotide/provider.go
@@ -61,6 +61,17 @@ var (
 	}
 )
 
+// Variants returns every VS Code distribution this provider supports.
+//
+// Exported for the source-tree monitor's Copilot-IDE supervisor
+// (specstoryai/getspecstory#257), which enumerates all workspaceStorage
+// locations to map chat activity back to repos rather than searching per
+// project. It has no caller within this branch yet — it goes live once that
+// monitor reaches dev and its `copilotide_monitor` build tag is dropped.
+func Variants() []Variant {
+	return []Variant{VSCode, VSCodeInsiders, VSCodium, VSCodiumInsiders}
+}
+
 // Provider implements the SPI Provider interface for the Copilot chat built
 // into a VS Code distribution (stock VS Code or VS Code Insiders).
 type Provider struct {

--- a/specstory-cli/pkg/providers/copilotide/provider.go
+++ b/specstory-cli/pkg/providers/copilotide/provider.go
@@ -115,8 +115,10 @@ func (p *Provider) Check(customCommand string) spi.CheckResult {
 func (p *Provider) DetectAgent(projectPath string, helpOutput bool) bool {
 	slog.Debug("DetectAgent: Checking for Copilot activity", "app", p.variant.AppName, "projectPath", projectPath)
 
-	// Try to find workspace for project
-	workspace, err := p.FindWorkspaceForProject(projectPath)
+	// Try to find all workspaces matching the project. A project can match several
+	// workspace entries (opened directly as a folder AND listed in .code-workspace
+	// files), and sessions may live in any of them.
+	workspaces, err := p.FindWorkspacesForProject(projectPath)
 	if err != nil {
 		slog.Debug("No workspace found for project", "projectPath", projectPath, "error", err)
 		if helpOutput {
@@ -129,41 +131,71 @@ func (p *Provider) DetectAgent(projectPath string, helpOutput bool) bool {
 		return false
 	}
 
-	// Check if workspace has any chat sessions
-	sessionFiles, err := LoadAllSessionFiles(workspace.Dir)
-	if err != nil || len(sessionFiles) == 0 {
-		slog.Debug("No chat sessions found", "workspace", workspace.Dir, "error", err)
-		if helpOutput {
-			fmt.Printf("\n❌ No %s Copilot chat sessions found\n", p.variant.AppName)
-			fmt.Printf("  • Workspace: %s\n", workspace.Dir)
-			fmt.Printf("  • Create at least one chat session in %s Copilot\n", p.variant.AppName)
-			fmt.Println()
+	// Any matching workspace with at least one chat session counts as activity.
+	for _, workspace := range workspaces {
+		sessionFiles, err := LoadAllSessionFiles(workspace.Dir)
+		if err != nil || len(sessionFiles) == 0 {
+			slog.Debug("No chat sessions found", "workspace", workspace.Dir, "error", err)
+			continue
 		}
-		return false
+		slog.Debug("Copilot activity detected",
+			"app", p.variant.AppName,
+			"workspace", workspace.Dir,
+			"sessionCount", len(sessionFiles))
+		return true
 	}
 
-	slog.Debug("Copilot activity detected", "app", p.variant.AppName, "sessionCount", len(sessionFiles))
-	return true
+	slog.Debug("No chat sessions found in any matching workspace",
+		"projectPath", projectPath, "workspaceCount", len(workspaces))
+	if helpOutput {
+		fmt.Printf("\n❌ No %s Copilot chat sessions found\n", p.variant.AppName)
+		for _, workspace := range workspaces {
+			fmt.Printf("  • Workspace: %s\n", workspace.Dir)
+		}
+		fmt.Printf("  • Create at least one chat session in %s Copilot\n", p.variant.AppName)
+		fmt.Println()
+	}
+	return false
 }
 
 // GetAgentChatSession retrieves a single chat session by ID
 func (p *Provider) GetAgentChatSession(projectPath string, sessionID string, debugRaw bool) (*spi.AgentChatSession, error) {
 	slog.Debug("GetAgentChatSession", "projectPath", projectPath, "sessionID", sessionID, "debugRaw", debugRaw)
 
-	// Find workspace for project
-	workspace, err := p.FindWorkspaceForProject(projectPath)
+	// Find all workspaces matching the project. The session may live in any of them
+	// (e.g. the project was opened both directly and via a .code-workspace file, and
+	// the session belongs to a workspace that is not the most recently used one).
+	workspaces, err := p.FindWorkspacesForProject(projectPath)
 	if err != nil {
 		return nil, fmt.Errorf("failed to find workspace: %w", err)
 	}
 
-	// Load specific session
-	session, err := LoadSessionByID(workspace.Dir, sessionID)
-	if err != nil {
-		return nil, fmt.Errorf("failed to load session: %w", err)
+	// Probe each matching workspace newest-first until the session is found. Only a
+	// missing session file means "try the next workspace"; any other error (e.g. a
+	// corrupt file) is a real failure and is surfaced immediately.
+	var session *VSCodeComposer
+	var workspaceDir string
+	for _, workspace := range workspaces {
+		loaded, loadErr := LoadSessionByID(workspace.Dir, sessionID)
+		if loadErr != nil {
+			if errors.Is(loadErr, ErrSessionNotFound) {
+				slog.Debug("Session not in workspace, trying next match",
+					"sessionId", sessionID, "workspace", workspace.Dir)
+				continue
+			}
+			return nil, fmt.Errorf("failed to load session: %w", loadErr)
+		}
+		session = loaded
+		workspaceDir = workspace.Dir
+		break
+	}
+	if session == nil {
+		return nil, fmt.Errorf("failed to load session: %w: %s (searched %d matching workspaces)",
+			ErrSessionNotFound, sessionID, len(workspaces))
 	}
 
-	// Load state file (optional)
-	state, err := LoadStateFile(workspace.Dir, sessionID)
+	// Load state file (optional) from the same workspace the session was found in
+	state, err := LoadStateFile(workspaceDir, sessionID)
 	if err != nil {
 		slog.Warn("Failed to load state file", "sessionId", sessionID, "error", err)
 	}
@@ -181,18 +213,79 @@ func (p *Provider) GetAgentChatSession(projectPath string, sessionID string, deb
 	return &agentSession, nil
 }
 
-// GetAgentChatSessions retrieves all chat sessions for the given project path
+// sessionFileRef pairs a session file with the workspace it came from, so per-session
+// state files can be resolved against the right workspace's chatEditingSessions.
+type sessionFileRef struct {
+	path         string
+	workspaceDir string
+}
+
+// collectProjectSessionFiles gathers session files across all matching workspaces,
+// iterated newest-first. Deduplication: within a workspace the .jsonl file is preferred
+// over the .json file for the same session (matching LoadSessionByID); across workspaces
+// the first-seen — i.e. newest — workspace wins for a session ID present in several.
+// Per-workspace enumeration failures are logged and skipped so one bad workspace doesn't
+// hide sessions in the others; an error is returned only when every workspace failed.
+func collectProjectSessionFiles(workspaces []WorkspaceMatch) ([]sessionFileRef, error) {
+	seen := make(map[string]bool)
+	var refs []sessionFileRef
+	var firstErr error
+	enumerated := false
+
+	for _, workspace := range workspaces {
+		files, err := LoadAllSessionFiles(workspace.Dir)
+		if err != nil {
+			slog.Warn("Failed to load session files from workspace",
+				"workspace", workspace.Dir, "error", err)
+			if firstErr == nil {
+				firstErr = err
+			}
+			continue
+		}
+		enumerated = true
+
+		// Pick one file per session ID within this workspace, preferring .jsonl.
+		byID := make(map[string]string, len(files))
+		for _, file := range files {
+			id := GetSessionIDFromPath(file)
+			if existing, ok := byID[id]; ok &&
+				(strings.HasSuffix(existing, ".jsonl") || !strings.HasSuffix(file, ".jsonl")) {
+				continue
+			}
+			byID[id] = file
+		}
+
+		// Iterate the file list (not byID) so output keeps deterministic filename order.
+		for _, file := range files {
+			id := GetSessionIDFromPath(file)
+			if byID[id] != file || seen[id] {
+				continue
+			}
+			seen[id] = true
+			refs = append(refs, sessionFileRef{path: file, workspaceDir: workspace.Dir})
+		}
+	}
+
+	if !enumerated && firstErr != nil {
+		return nil, firstErr
+	}
+	return refs, nil
+}
+
+// GetAgentChatSessions retrieves all chat sessions for the given project path,
+// aggregated across every matching workspace (a project can match several — opened
+// directly as a folder and via .code-workspace files).
 func (p *Provider) GetAgentChatSessions(projectPath string, debugRaw bool, progress spi.ProgressCallback) ([]spi.AgentChatSession, error) {
 	slog.Debug("GetAgentChatSessions", "projectPath", projectPath, "debugRaw", debugRaw)
 
-	// Find workspace for project
-	workspace, err := p.FindWorkspaceForProject(projectPath)
+	// Find all workspaces matching the project
+	workspaces, err := p.FindWorkspacesForProject(projectPath)
 	if err != nil {
 		return nil, fmt.Errorf("failed to find workspace: %w", err)
 	}
 
-	// Load all session files
-	sessionFiles, err := LoadAllSessionFiles(workspace.Dir)
+	// Load session files from all matching workspaces (deduplicated, newest workspace wins)
+	sessionFiles, err := collectProjectSessionFiles(workspaces)
 	if err != nil {
 		return nil, fmt.Errorf("failed to load session files: %w", err)
 	}
@@ -201,15 +294,15 @@ func (p *Provider) GetAgentChatSessions(projectPath string, debugRaw bool, progr
 	processedCount := 0
 	totalCount := len(sessionFiles)
 
-	for _, sessionFile := range sessionFiles {
-		composer, err := LoadSessionFile(sessionFile)
+	for _, ref := range sessionFiles {
+		composer, err := LoadSessionFile(ref.path)
 		if err != nil {
-			slog.Warn("Failed to load session", "file", sessionFile, "error", err)
+			slog.Warn("Failed to load session", "file", ref.path, "error", err)
 			continue
 		}
 
-		// Load state file (optional)
-		state, err := LoadStateFile(workspace.Dir, composer.SessionID)
+		// Load state file (optional) from the workspace the session file came from
+		state, err := LoadStateFile(ref.workspaceDir, composer.SessionID)
 		if err != nil {
 			slog.Warn("Failed to load state file", "sessionId", composer.SessionID, "error", err)
 		}
@@ -250,17 +343,18 @@ func (p *Provider) ListAgentChatSessions(projectPath string) ([]spi.SessionMetad
 	slog.Debug("ListAgentChatSessions: Loading Copilot session list",
 		"app", p.variant.AppName, "projectPath", projectPath)
 
-	// Step 1: Find workspace for project
-	workspace, err := p.FindWorkspaceForProject(projectPath)
+	// Step 1: Find all workspaces matching the project (sessions may live in any of them)
+	workspaces, err := p.FindWorkspacesForProject(projectPath)
 	if err != nil {
 		slog.Debug("No workspace found for project", "error", err)
 		return []spi.SessionMetadata{}, nil // Return empty list if no workspace
 	}
 
-	slog.Debug("Found workspace for project", "workspaceDir", workspace.Dir)
+	slog.Debug("Found workspaces for project", "workspaceCount", len(workspaces))
 
-	// Step 2: Load all session files
-	sessionFiles, err := LoadAllSessionFiles(workspace.Dir)
+	// Step 2: Load session files from all matching workspaces (deduplicated,
+	// newest workspace wins for a session ID present in several)
+	sessionFiles, err := collectProjectSessionFiles(workspaces)
 	if err != nil {
 		return nil, fmt.Errorf("failed to load session files: %w", err)
 	}
@@ -274,15 +368,15 @@ func (p *Provider) ListAgentChatSessions(projectPath string) ([]spi.SessionMetad
 
 	// Step 3: Extract metadata for each session
 	metadataList := make([]spi.SessionMetadata, 0, len(sessionFiles))
-	for _, sessionFile := range sessionFiles {
-		composer, err := LoadSessionFile(sessionFile)
+	for _, ref := range sessionFiles {
+		composer, err := LoadSessionFile(ref.path)
 		if err != nil {
-			slog.Warn("Failed to load session file", "file", sessionFile, "error", err)
+			slog.Warn("Failed to load session file", "file", ref.path, "error", err)
 			continue
 		}
 
-		// Load state file to check for editing operations
-		state, err := LoadStateFile(workspace.Dir, composer.SessionID)
+		// Load state file (from the owning workspace) to check for editing operations
+		state, err := LoadStateFile(ref.workspaceDir, composer.SessionID)
 		if err != nil {
 			slog.Warn("Failed to load state file", "sessionId", composer.SessionID, "error", err)
 		}
@@ -493,18 +587,25 @@ func collectWorkspaceSessionRefs(workspaceDir string, refByID map[string]spi.Glo
 	}
 }
 
-// WatchAgent watches for new/updated chat sessions
+// WatchAgent watches for new/updated chat sessions across ALL workspaces matching the
+// project, so activity in any of them (folder-opened or .code-workspace-opened windows)
+// is picked up, not just the most recently used one.
 func (p *Provider) WatchAgent(ctx context.Context, projectPath string, debugRaw bool, sessionCallback func(*spi.AgentChatSession)) error {
 	slog.Debug("WatchAgent", "projectPath", projectPath, "debugRaw", debugRaw)
 
-	// Find workspace for project
-	workspace, err := p.FindWorkspaceForProject(projectPath)
+	// Find all workspaces matching the project
+	workspaces, err := p.FindWorkspacesForProject(projectPath)
 	if err != nil {
 		return fmt.Errorf("failed to find workspace: %w", err)
 	}
 
-	// Start watching the chatSessions directory
-	return p.WatchChatSessions(ctx, workspace.Dir, projectPath, debugRaw, sessionCallback)
+	workspaceDirs := make([]string, len(workspaces))
+	for i, workspace := range workspaces {
+		workspaceDirs[i] = workspace.Dir
+	}
+
+	// Start watching the chatSessions directory of every matching workspace
+	return p.WatchChatSessions(ctx, workspaceDirs, projectPath, debugRaw, sessionCallback)
 }
 
 // extractCopilotIDESessionMetadata extracts lightweight session metadata from a VSCodeComposer

--- a/specstory-cli/pkg/providers/copilotide/watcher.go
+++ b/specstory-cli/pkg/providers/copilotide/watcher.go
@@ -13,20 +13,25 @@ import (
 	"github.com/specstoryai/getspecstory/specstory-cli/pkg/spi"
 )
 
-// WatchChatSessions watches the chatSessions directory for new/modified session files
+// WatchChatSessions watches the chatSessions directory of every given workspace for
+// new/modified session files. A project can match several workspace entries (opened
+// directly as a folder and via .code-workspace files), and a session update can land
+// in any of them, so a single fsnotify watcher is attached to all their directories.
+//
+// Limitation: workspaceDirs comes from the matcher with requireChatSessions=true, so a
+// matching workspace whose chatSessions directory does not exist yet is not included
+// and won't be picked up until the watch restarts — watching for the directory's
+// creation would require a parent-directory watch that this watcher doesn't have.
 func (p *Provider) WatchChatSessions(
 	ctx context.Context,
-	workspaceDir string,
+	workspaceDirs []string,
 	projectPath string,
 	debugRaw bool,
 	sessionCallback func(*spi.AgentChatSession),
 ) error {
-	chatSessionsPath := GetChatSessionsPath(workspaceDir)
-
 	slog.Info("Starting Copilot watcher",
 		"app", p.variant.AppName,
-		"workspaceDir", workspaceDir,
-		"chatSessionsPath", chatSessionsPath)
+		"workspaceCount", len(workspaceDirs))
 
 	// Create fsnotify watcher
 	watcher, err := fsnotify.NewWatcher()
@@ -44,12 +49,23 @@ func (p *Provider) WatchChatSessions(
 	var callbackWg sync.WaitGroup
 	defer callbackWg.Wait()
 
-	// Watch the chatSessions directory
-	if err := watcher.Add(chatSessionsPath); err != nil {
-		return fmt.Errorf("failed to watch directory: %w", err)
+	// Watch the chatSessions directory of every matching workspace. A failure to add
+	// one directory (e.g. deleted since matching) must not silence the others, so it
+	// only degrades to a warning; the watch fails outright only when nothing is watched.
+	watchedCount := 0
+	for _, workspaceDir := range workspaceDirs {
+		chatSessionsPath := GetChatSessionsPath(workspaceDir)
+		if err := watcher.Add(chatSessionsPath); err != nil {
+			slog.Warn("Failed to watch chatSessions directory",
+				"path", chatSessionsPath, "error", err)
+			continue
+		}
+		watchedCount++
+		slog.Info("Watching chatSessions directory", "path", chatSessionsPath)
 	}
-
-	slog.Info("Watching chatSessions directory", "path", chatSessionsPath)
+	if watchedCount == 0 {
+		return fmt.Errorf("failed to watch any chatSessions directory (%d candidates)", len(workspaceDirs))
+	}
 
 	// Track known sessions and their modification times
 	knownSessions := make(map[string]int64)
@@ -58,11 +74,16 @@ func (p *Provider) WatchChatSessions(
 	lastProcessed := make(map[string]time.Time)
 	debounceWindow := 500 * time.Millisecond
 
-	// Process existing sessions first
-	existingSessions, err := LoadAllSessionFiles(workspaceDir)
-	if err != nil {
-		slog.Warn("Failed to load existing sessions", "error", err)
-	} else {
+	// Process existing sessions first, across all watched workspaces. knownSessions is
+	// keyed by session ID, so a session present in several workspaces is tracked once
+	// with the newest LastMessageDate seen — later events only fire the callback when
+	// they carry something newer.
+	for _, workspaceDir := range workspaceDirs {
+		existingSessions, err := LoadAllSessionFiles(workspaceDir)
+		if err != nil {
+			slog.Warn("Failed to load existing sessions", "workspace", workspaceDir, "error", err)
+			continue
+		}
 		for _, sessionPath := range existingSessions {
 			composer, err := LoadSessionFile(sessionPath)
 			if err != nil {
@@ -70,8 +91,10 @@ func (p *Provider) WatchChatSessions(
 				continue
 			}
 
-			// Track as known
-			knownSessions[composer.SessionID] = composer.LastMessageDate
+			// Track as known, keeping the newest LastMessageDate across workspaces
+			if known, exists := knownSessions[composer.SessionID]; !exists || composer.LastMessageDate > known {
+				knownSessions[composer.SessionID] = composer.LastMessageDate
+			}
 
 			slog.Debug("Tracked existing session", "sessionId", composer.SessionID)
 		}
@@ -136,8 +159,11 @@ func (p *Provider) WatchChatSessions(
 					slog.Info("Session updated", "sessionId", sessionID, "name", composer.Name)
 				}
 
-				// Load state file (optional)
-				state, err := LoadStateFile(workspaceDir, sessionID)
+				// Load state file (optional) from the workspace the event came from.
+				// The event path is <workspaceDir>/chatSessions/<file>, so the owning
+				// workspace directory is two levels up from the changed file.
+				eventWorkspaceDir := filepath.Dir(filepath.Dir(event.Name))
+				state, err := LoadStateFile(eventWorkspaceDir, sessionID)
 				if err != nil {
 					slog.Warn("Failed to load state file", "sessionId", sessionID, "error", err)
 				}

--- a/specstory-cli/pkg/providers/copilotide/workspace.go
+++ b/specstory-cli/pkg/providers/copilotide/workspace.go
@@ -247,6 +247,29 @@ func sortWorkspacesNewestFirst(matches []WorkspaceMatch) {
 	})
 }
 
+// The exported wrappers below expose this package's workspace-mapping helpers
+// for the source-tree monitor's Copilot-IDE supervisor
+// (specstoryai/getspecstory#257), which enumerates workspaceStorage itself to
+// map workspaces to repos. They have no caller within this branch yet — they go
+// live once that monitor reaches dev and its `copilotide_monitor` build tag is
+// dropped. Kept as thin wrappers so the internal helpers stay unexported.
+
+// ReadWorkspaceJSON reads and parses a workspace.json file. See the note above.
+func ReadWorkspaceJSON(path string) (*WorkspaceJSON, error) {
+	return readWorkspaceJSON(path)
+}
+
+// URIToPath converts a file:// URI to a local filesystem path. See the note above.
+func URIToPath(uri string) (string, error) {
+	return uriToPath(uri)
+}
+
+// CollectCodeWorkspaceFolders reads a .code-workspace JSON file and returns the
+// canonical paths of all listed folders. See the note above.
+func CollectCodeWorkspaceFolders(workspaceFilePath string) []string {
+	return collectCodeWorkspaceFolders(workspaceFilePath)
+}
+
 // collectCodeWorkspaceFolders reads a .code-workspace JSON file and returns the
 // canonical paths of all listed folders. Relative paths are resolved against the
 // workspace file's directory.

--- a/specstory-cli/pkg/providers/copilotide/workspace.go
+++ b/specstory-cli/pkg/providers/copilotide/workspace.go
@@ -7,7 +7,9 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
+	"time"
 
 	"github.com/specstoryai/getspecstory/specstory-cli/pkg/spi"
 )
@@ -26,17 +28,47 @@ type WorkspaceJSON struct {
 	Folder    string `json:"folder,omitempty"`    // For single folder workspaces
 }
 
-// FindWorkspaceForProject finds the workspace directory that matches the given project path
-// Returns the workspace match or an error if not found
+// FindWorkspaceForProject finds the single best workspace directory that matches the
+// given project path. Callers that need exactly one target (e.g. reconstruction writes)
+// use this; read paths should use FindWorkspacesForProject instead, because a project
+// can legitimately match several workspace entries (opened directly as a folder AND
+// listed in one or more .code-workspace files) and sessions may live in any of them.
 func (p *Provider) FindWorkspaceForProject(projectPath string) (*WorkspaceMatch, error) {
 	return p.findWorkspaceForProject(projectPath, true)
 }
 
-// findWorkspaceForProject matches projectPath against every workspace.json in the
-// variant's storage directory. requireChatSessions filters out matches that have never
-// had a chat session — wanted when reading sessions, not when picking a write target
-// for reconstruction (the resume flow creates the chatSessions directory when writing).
+// FindWorkspacesForProject finds ALL workspace directories that match the given project
+// path, sorted newest-first by state.vscdb modification time (so the most-likely-active
+// workspace is tried first and iteration order is deterministic).
+func (p *Provider) FindWorkspacesForProject(projectPath string) ([]WorkspaceMatch, error) {
+	return p.findWorkspacesForProject(projectPath, true)
+}
+
+// findWorkspaceForProject is "first of plural": it returns the newest matching workspace.
+// Kept for callers that need exactly one target — the reconstruction write path — where
+// newest ≈ the VS Code window the user is most likely to open next.
 func (p *Provider) findWorkspaceForProject(projectPath string, requireChatSessions bool) (*WorkspaceMatch, error) {
+	matches, err := p.findWorkspacesForProject(projectPath, requireChatSessions)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(matches) > 1 {
+		slog.Warn("Multiple workspaces match project path, selecting newest",
+			"projectPath", projectPath,
+			"matchCount", len(matches),
+			"selectedWorkspaceID", matches[0].ID)
+	}
+
+	return &matches[0], nil
+}
+
+// findWorkspacesForProject matches projectPath against every workspace.json in the
+// variant's storage directory and returns all matches, sorted newest-first by
+// state.vscdb mtime. requireChatSessions filters out matches that have never had a
+// chat session — wanted when reading sessions, not when picking a write target for
+// reconstruction (the resume flow creates the chatSessions directory when writing).
+func (p *Provider) findWorkspacesForProject(projectPath string, requireChatSessions bool) ([]WorkspaceMatch, error) {
 	// Get canonical project path (resolve symlinks, normalize case)
 	absProjectPath, err := filepath.Abs(projectPath)
 	if err != nil {
@@ -189,45 +221,30 @@ func (p *Provider) findWorkspaceForProject(projectPath string, requireChatSessio
 		return nil, fmt.Errorf("no workspace found for project path %s (searched VS Code workspace storage in %s; open the folder in VS Code once to create one)", projectPath, workspaceStoragePath)
 	}
 
-	// If multiple matches, return the newest one (based on state.vscdb modification time)
-	if len(matches) > 1 {
-		slog.Warn("Multiple workspaces match project path, selecting newest",
-			"projectPath", projectPath,
-			"matchCount", len(matches))
-		return selectNewestWorkspace(matches)
-	}
-
-	return &matches[0], nil
+	sortWorkspacesNewestFirst(matches)
+	return matches, nil
 }
 
-// selectNewestWorkspace returns the workspace with the newest state.vscdb modification time
-func selectNewestWorkspace(matches []WorkspaceMatch) (*WorkspaceMatch, error) {
-	var newest *WorkspaceMatch
-	var newestTime int64
-
-	for i := range matches {
-		match := &matches[i]
+// sortWorkspacesNewestFirst orders matches by descending state.vscdb modification time,
+// so the workspace the user most recently had open comes first. A workspace whose
+// state.vscdb can't be stat'd gets the zero time and sorts last rather than erroring
+// out the whole lookup. The sort is stable so ties keep directory-listing order,
+// keeping iteration deterministic across calls.
+func sortWorkspacesNewestFirst(matches []WorkspaceMatch) {
+	modTimes := make(map[string]time.Time, len(matches))
+	for _, match := range matches {
 		stateDBPath := GetWorkspaceStateDBPath(match.Dir)
-
 		info, err := os.Stat(stateDBPath)
 		if err != nil {
 			slog.Debug("Failed to stat state.vscdb", "path", stateDBPath, "error", err)
 			continue
 		}
-
-		modTime := info.ModTime().Unix()
-		if newest == nil || modTime > newestTime {
-			newest = match
-			newestTime = modTime
-		}
+		modTimes[match.ID] = info.ModTime()
 	}
 
-	if newest == nil {
-		return &matches[0], nil // Fall back to first match
-	}
-
-	slog.Debug("Selected newest workspace", "workspaceID", newest.ID, "modTime", newestTime)
-	return newest, nil
+	sort.SliceStable(matches, func(i, j int) bool {
+		return modTimes[matches[i].ID].After(modTimes[matches[j].ID])
+	})
 }
 
 // collectCodeWorkspaceFolders reads a .code-workspace JSON file and returns the

--- a/specstory-cli/pkg/providers/copilotide/workspace_test.go
+++ b/specstory-cli/pkg/providers/copilotide/workspace_test.go
@@ -1,0 +1,395 @@
+package copilotide
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+)
+
+// Note: uriToPath is already covered by TestUriToPath in parser_test.go, so it is
+// deliberately not re-tested here.
+
+// setupWorkspaceStorage redirects HOME to a fresh temp dir and creates the VS Code
+// ("Code" variant) workspace storage directory inside it, so findWorkspaceForProject
+// resolves against a fully test-controlled filesystem. os.UserHomeDir reads $HOME on
+// both macOS and Linux, so t.Setenv is enough to redirect GetWorkspaceStoragePath.
+func setupWorkspaceStorage(t *testing.T) string {
+	t.Helper()
+
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	var storage string
+	switch runtime.GOOS {
+	case "darwin":
+		storage = filepath.Join(home, "Library", "Application Support", "Code", "User", "workspaceStorage")
+	case "linux":
+		storage = filepath.Join(home, ".config", "Code", "User", "workspaceStorage")
+	default:
+		t.Skipf("workspace storage layout not defined for GOOS %s", runtime.GOOS)
+	}
+
+	if err := os.MkdirAll(storage, 0755); err != nil {
+		t.Fatalf("failed to create workspace storage dir: %v", err)
+	}
+	return storage
+}
+
+// addWorkspaceEntry creates <storage>/<id>/workspace.json with the given content and,
+// optionally, an empty chatSessions directory (the marker findWorkspaceForProject
+// requires when requireChatSessions is true).
+func addWorkspaceEntry(t *testing.T, storage, id, workspaceJSON string, withChatSessions bool) string {
+	t.Helper()
+
+	dir := filepath.Join(storage, id)
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		t.Fatalf("failed to create workspace entry dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "workspace.json"), []byte(workspaceJSON), 0644); err != nil {
+		t.Fatalf("failed to write workspace.json: %v", err)
+	}
+	if withChatSessions {
+		if err := os.MkdirAll(filepath.Join(dir, "chatSessions"), 0755); err != nil {
+			t.Fatalf("failed to create chatSessions dir: %v", err)
+		}
+	}
+	return dir
+}
+
+// canonicalTempDir returns a fresh temp dir with symlinks resolved, so paths written
+// into fixtures compare equal to what spi.GetCanonicalPath produces (e.g. /var vs
+// /private/var on macOS).
+func canonicalTempDir(t *testing.T) string {
+	t.Helper()
+
+	dir := t.TempDir()
+	resolved, err := filepath.EvalSymlinks(dir)
+	if err != nil {
+		return dir
+	}
+	return resolved
+}
+
+// writeStateDB creates a state.vscdb file in the workspace dir and pins its mtime,
+// which selectNewestWorkspace uses to break ties between multiple matches.
+func writeStateDB(t *testing.T, workspaceDir string, mtime time.Time) {
+	t.Helper()
+
+	path := filepath.Join(workspaceDir, "state.vscdb")
+	if err := os.WriteFile(path, []byte("db"), 0644); err != nil {
+		t.Fatalf("failed to write state.vscdb: %v", err)
+	}
+	if err := os.Chtimes(path, mtime, mtime); err != nil {
+		t.Fatalf("failed to set state.vscdb mtime: %v", err)
+	}
+}
+
+func TestFindWorkspaceForProject(t *testing.T) {
+	tests := []struct {
+		name                string
+		requireChatSessions bool
+		// setup builds the HOME/workspaceStorage fixtures and returns the
+		// projectPath to search for.
+		setup           func(t *testing.T) string
+		wantID          string
+		wantErrContains string
+	}{
+		{
+			name:                "direct folder match among multiple entries",
+			requireChatSessions: true,
+			setup: func(t *testing.T) string {
+				storage := setupWorkspaceStorage(t)
+				project := canonicalTempDir(t)
+				other := canonicalTempDir(t)
+				addWorkspaceEntry(t, storage, "ws-other", `{"folder":"file://`+other+`"}`, true)
+				addWorkspaceEntry(t, storage, "ws-match", `{"folder":"file://`+project+`"}`, true)
+				return project
+			},
+			wantID: "ws-match",
+		},
+		{
+			name:                "no matching workspace",
+			requireChatSessions: true,
+			setup: func(t *testing.T) string {
+				storage := setupWorkspaceStorage(t)
+				other := canonicalTempDir(t)
+				addWorkspaceEntry(t, storage, "ws-other", `{"folder":"file://`+other+`"}`, true)
+				return canonicalTempDir(t)
+			},
+			wantErrContains: "no workspace found",
+		},
+		{
+			name:                "workspace storage directory missing",
+			requireChatSessions: true,
+			setup: func(t *testing.T) string {
+				// HOME redirected but no workspaceStorage created underneath.
+				t.Setenv("HOME", t.TempDir())
+				return canonicalTempDir(t)
+			},
+			wantErrContains: "workspace storage directory not found",
+		},
+		{
+			name:                "match without chatSessions filtered when required",
+			requireChatSessions: true,
+			setup: func(t *testing.T) string {
+				storage := setupWorkspaceStorage(t)
+				project := canonicalTempDir(t)
+				addWorkspaceEntry(t, storage, "ws-no-chat", `{"folder":"file://`+project+`"}`, false)
+				return project
+			},
+			wantErrContains: "no workspace found",
+		},
+		{
+			name:                "match without chatSessions kept for reconstruction targets",
+			requireChatSessions: false,
+			setup: func(t *testing.T) string {
+				storage := setupWorkspaceStorage(t)
+				project := canonicalTempDir(t)
+				addWorkspaceEntry(t, storage, "ws-no-chat", `{"folder":"file://`+project+`"}`, false)
+				return project
+			},
+			wantID: "ws-no-chat",
+		},
+		{
+			name:                "multiple matches select newest state.vscdb",
+			requireChatSessions: true,
+			setup: func(t *testing.T) string {
+				storage := setupWorkspaceStorage(t)
+				project := canonicalTempDir(t)
+				oldDir := addWorkspaceEntry(t, storage, "ws-old", `{"folder":"file://`+project+`"}`, true)
+				newDir := addWorkspaceEntry(t, storage, "ws-new", `{"folder":"file://`+project+`"}`, true)
+				writeStateDB(t, oldDir, time.Now().Add(-48*time.Hour))
+				writeStateDB(t, newDir, time.Now().Add(-1*time.Hour))
+				return project
+			},
+			wantID: "ws-new",
+		},
+		{
+			name:                "method 3: workspace.json points at code-workspace listing the folder",
+			requireChatSessions: true,
+			setup: func(t *testing.T) string {
+				storage := setupWorkspaceStorage(t)
+				base := canonicalTempDir(t)
+				project := filepath.Join(base, "my-project")
+				if err := os.Mkdir(project, 0755); err != nil {
+					t.Fatalf("mkdir project: %v", err)
+				}
+				// The .code-workspace file lives in a sibling dir and lists the
+				// project folder via a relative path.
+				wsFileDir := filepath.Join(base, "workspaces")
+				if err := os.Mkdir(wsFileDir, 0755); err != nil {
+					t.Fatalf("mkdir workspaces: %v", err)
+				}
+				wsFile := filepath.Join(wsFileDir, "multi.code-workspace")
+				if err := os.WriteFile(wsFile, []byte(`{"folders":[{"path":"../my-project"}]}`), 0644); err != nil {
+					t.Fatalf("write code-workspace: %v", err)
+				}
+				addWorkspaceEntry(t, storage, "ws-multiroot", `{"workspace":"file://`+wsFile+`"}`, true)
+				return project
+			},
+			wantID: "ws-multiroot",
+		},
+		{
+			name:                "method 4: project path is a code-workspace file matching a folder entry",
+			requireChatSessions: true,
+			setup: func(t *testing.T) string {
+				storage := setupWorkspaceStorage(t)
+				base := canonicalTempDir(t)
+				project := filepath.Join(base, "my-project")
+				if err := os.Mkdir(project, 0755); err != nil {
+					t.Fatalf("mkdir project: %v", err)
+				}
+				wsFile := filepath.Join(base, "multi.code-workspace")
+				if err := os.WriteFile(wsFile, []byte(`{"folders":[{"path":"my-project"}]}`), 0644); err != nil {
+					t.Fatalf("write code-workspace: %v", err)
+				}
+				// The storage entry was created by opening the folder directly, but
+				// the caller queries with the .code-workspace file path.
+				addWorkspaceEntry(t, storage, "ws-from-folder", `{"folder":"file://`+project+`"}`, true)
+				return wsFile
+			},
+			wantID: "ws-from-folder",
+		},
+		{
+			name:                "malformed and non-file entries are skipped, valid match still found",
+			requireChatSessions: true,
+			setup: func(t *testing.T) string {
+				storage := setupWorkspaceStorage(t)
+				project := canonicalTempDir(t)
+				addWorkspaceEntry(t, storage, "ws-bad-json", `not json`, true)
+				addWorkspaceEntry(t, storage, "ws-empty", `{}`, true)
+				addWorkspaceEntry(t, storage, "ws-remote", `{"folder":"vscode-remote://wsl/home/user/proj"}`, true)
+				addWorkspaceEntry(t, storage, "ws-good", `{"folder":"file://`+project+`"}`, true)
+				return project
+			},
+			wantID: "ws-good",
+		},
+		{
+			name:                "non-file URI alone cannot match",
+			requireChatSessions: true,
+			setup: func(t *testing.T) string {
+				storage := setupWorkspaceStorage(t)
+				project := canonicalTempDir(t)
+				// URI scheme is unsupported, so even a path-identical entry is skipped.
+				addWorkspaceEntry(t, storage, "ws-remote", `{"folder":"vscode-remote://wsl`+project+`"}`, true)
+				return project
+			},
+			wantErrContains: "no workspace found",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			projectPath := tt.setup(t)
+			p := NewProvider(VSCode)
+
+			// Exercise the exported wrapper for the requireChatSessions=true cases
+			// so its delegation is covered too.
+			var match *WorkspaceMatch
+			var err error
+			if tt.requireChatSessions {
+				match, err = p.FindWorkspaceForProject(projectPath)
+			} else {
+				match, err = p.findWorkspaceForProject(projectPath, false)
+			}
+
+			if tt.wantErrContains != "" {
+				if err == nil {
+					t.Fatalf("expected error containing %q, got match %+v", tt.wantErrContains, match)
+				}
+				if !strings.Contains(err.Error(), tt.wantErrContains) {
+					t.Errorf("error = %q, want it to contain %q", err.Error(), tt.wantErrContains)
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if match.ID != tt.wantID {
+				t.Errorf("match.ID = %q, want %q", match.ID, tt.wantID)
+			}
+			if match.Dir == "" || match.URI == "" || match.Path == "" {
+				t.Errorf("match has empty fields: %+v", match)
+			}
+		})
+	}
+}
+
+func TestCollectCodeWorkspaceFolders(t *testing.T) {
+	base := canonicalTempDir(t)
+	relProject := filepath.Join(base, "rel-project")
+	absProject := filepath.Join(base, "abs-project")
+	for _, dir := range []string{relProject, absProject} {
+		if err := os.Mkdir(dir, 0755); err != nil {
+			t.Fatalf("mkdir %s: %v", dir, err)
+		}
+	}
+
+	tests := []struct {
+		name    string
+		content string
+		want    []string
+	}{
+		{
+			name:    "relative and absolute folder paths resolved",
+			content: `{"folders":[{"path":"rel-project"},{"path":"` + absProject + `"}]}`,
+			want:    []string{relProject, absProject},
+		},
+		{
+			name:    "empty path entries skipped",
+			content: `{"folders":[{"path":""},{"path":"rel-project"}]}`,
+			want:    []string{relProject},
+		},
+		{
+			name:    "no folders key",
+			content: `{"settings":{}}`,
+			want:    nil,
+		},
+		{
+			name:    "malformed JSON returns nil",
+			content: `{"folders":[`,
+			want:    nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			wsFile := filepath.Join(base, "test.code-workspace")
+			if err := os.WriteFile(wsFile, []byte(tt.content), 0644); err != nil {
+				t.Fatalf("write code-workspace: %v", err)
+			}
+
+			got := collectCodeWorkspaceFolders(wsFile)
+			if len(got) != len(tt.want) {
+				t.Fatalf("collectCodeWorkspaceFolders() = %v, want %v", got, tt.want)
+			}
+			for i := range tt.want {
+				if got[i] != tt.want[i] {
+					t.Errorf("folder[%d] = %q, want %q", i, got[i], tt.want[i])
+				}
+			}
+		})
+	}
+
+	t.Run("missing file returns nil", func(t *testing.T) {
+		if got := collectCodeWorkspaceFolders(filepath.Join(base, "does-not-exist.code-workspace")); got != nil {
+			t.Errorf("expected nil for missing file, got %v", got)
+		}
+	})
+}
+
+func TestCodeWorkspaceContainsFolder(t *testing.T) {
+	base := canonicalTempDir(t)
+	project := filepath.Join(base, "my-project")
+	if err := os.Mkdir(project, 0755); err != nil {
+		t.Fatalf("mkdir project: %v", err)
+	}
+	wsFile := filepath.Join(base, "test.code-workspace")
+
+	tests := []struct {
+		name    string
+		content string
+		folder  string
+		want    bool
+	}{
+		{
+			name:    "relative path resolves to target folder",
+			content: `{"folders":[{"path":"my-project"}]}`,
+			folder:  project,
+			want:    true,
+		},
+		{
+			name:    "absolute path matches target folder",
+			content: `{"folders":[{"path":"` + project + `"}]}`,
+			folder:  project,
+			want:    true,
+		},
+		{
+			name:    "unrelated folder does not match",
+			content: `{"folders":[{"path":"other-project"}]}`,
+			folder:  project,
+			want:    false,
+		},
+		{
+			name:    "malformed JSON never matches",
+			content: `not json`,
+			folder:  project,
+			want:    false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := os.WriteFile(wsFile, []byte(tt.content), 0644); err != nil {
+				t.Fatalf("write code-workspace: %v", err)
+			}
+			if got := codeWorkspaceContainsFolder(wsFile, tt.folder); got != tt.want {
+				t.Errorf("codeWorkspaceContainsFolder() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/specstory-cli/pkg/providers/copilotide/workspace_test.go
+++ b/specstory-cli/pkg/providers/copilotide/workspace_test.go
@@ -279,6 +279,221 @@ func TestFindWorkspaceForProject(t *testing.T) {
 	}
 }
 
+// writeSessionFile writes a minimal non-empty chat session (one request) into the
+// workspace's chatSessions directory. The title distinguishes copies of the same
+// session ID across workspaces, so tests can verify which workspace's copy won
+// deduplication (RawData round-trips customTitle).
+func writeSessionFile(t *testing.T, workspaceDir, sessionID, title string) {
+	t.Helper()
+
+	content := `{"sessionId":"` + sessionID + `","customTitle":"` + title + `",` +
+		`"creationDate":1700000000000,"lastMessageDate":1700000001000,` +
+		`"requests":[{"requestId":"r1","timestamp":1700000000500,"message":{"text":"hello"}}]}`
+	path := filepath.Join(workspaceDir, "chatSessions", sessionID+".json")
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatalf("failed to write session file: %v", err)
+	}
+}
+
+// setupTwoMatchingWorkspaces builds a project that matches two workspace entries —
+// the multi-workspace situation this package's read paths must aggregate across —
+// and returns the project path plus both workspace dirs. ws-newer has the newer
+// state.vscdb, so it sorts first.
+func setupTwoMatchingWorkspaces(t *testing.T) (projectPath, olderDir, newerDir string) {
+	t.Helper()
+
+	storage := setupWorkspaceStorage(t)
+	projectPath = canonicalTempDir(t)
+	olderDir = addWorkspaceEntry(t, storage, "ws-older", `{"folder":"file://`+projectPath+`"}`, true)
+	newerDir = addWorkspaceEntry(t, storage, "ws-newer", `{"folder":"file://`+projectPath+`"}`, true)
+	writeStateDB(t, olderDir, time.Now().Add(-48*time.Hour))
+	writeStateDB(t, newerDir, time.Now().Add(-1*time.Hour))
+	return projectPath, olderDir, newerDir
+}
+
+// TestFindWorkspacesForProject verifies the plural lookup returns every matching
+// workspace, sorted newest-first by state.vscdb mtime.
+func TestFindWorkspacesForProject(t *testing.T) {
+	tests := []struct {
+		name string
+		// setup builds the fixtures and returns the projectPath to search for.
+		setup           func(t *testing.T) string
+		wantIDs         []string // expected match IDs in expected order
+		wantErrContains string
+	}{
+		{
+			name: "all matches returned newest-first",
+			setup: func(t *testing.T) string {
+				storage := setupWorkspaceStorage(t)
+				project := canonicalTempDir(t)
+				other := canonicalTempDir(t)
+				oldDir := addWorkspaceEntry(t, storage, "ws-old", `{"folder":"file://`+project+`"}`, true)
+				newDir := addWorkspaceEntry(t, storage, "ws-new", `{"folder":"file://`+project+`"}`, true)
+				addWorkspaceEntry(t, storage, "ws-unrelated", `{"folder":"file://`+other+`"}`, true)
+				writeStateDB(t, oldDir, time.Now().Add(-48*time.Hour))
+				writeStateDB(t, newDir, time.Now().Add(-1*time.Hour))
+				return project
+			},
+			wantIDs: []string{"ws-new", "ws-old"},
+		},
+		{
+			name: "match without state.vscdb sorts last",
+			setup: func(t *testing.T) string {
+				storage := setupWorkspaceStorage(t)
+				project := canonicalTempDir(t)
+				// ReadDir returns ws-no-db before ws-with-db (alphabetical), so only
+				// the mtime sort can put ws-with-db first.
+				addWorkspaceEntry(t, storage, "ws-no-db", `{"folder":"file://`+project+`"}`, true)
+				withDB := addWorkspaceEntry(t, storage, "ws-with-db", `{"folder":"file://`+project+`"}`, true)
+				writeStateDB(t, withDB, time.Now().Add(-1*time.Hour))
+				return project
+			},
+			wantIDs: []string{"ws-with-db", "ws-no-db"},
+		},
+		{
+			name: "no matching workspace",
+			setup: func(t *testing.T) string {
+				storage := setupWorkspaceStorage(t)
+				other := canonicalTempDir(t)
+				addWorkspaceEntry(t, storage, "ws-other", `{"folder":"file://`+other+`"}`, true)
+				return canonicalTempDir(t)
+			},
+			wantErrContains: "no workspace found",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			projectPath := tt.setup(t)
+			p := NewProvider(VSCode)
+
+			matches, err := p.FindWorkspacesForProject(projectPath)
+
+			if tt.wantErrContains != "" {
+				if err == nil {
+					t.Fatalf("expected error containing %q, got %d matches", tt.wantErrContains, len(matches))
+				}
+				if !strings.Contains(err.Error(), tt.wantErrContains) {
+					t.Errorf("error = %q, want it to contain %q", err.Error(), tt.wantErrContains)
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if len(matches) != len(tt.wantIDs) {
+				t.Fatalf("got %d matches, want %d: %+v", len(matches), len(tt.wantIDs), matches)
+			}
+			for i, wantID := range tt.wantIDs {
+				if matches[i].ID != wantID {
+					t.Errorf("matches[%d].ID = %q, want %q", i, matches[i].ID, wantID)
+				}
+			}
+		})
+	}
+}
+
+// TestGetAgentChatSession_SessionInOlderWorkspace reproduces the multi-workspace bug:
+// a session that lives only in the OLDER of two matching workspaces must still be
+// found, instead of erroring "session not found" because the newest workspace won.
+func TestGetAgentChatSession_SessionInOlderWorkspace(t *testing.T) {
+	projectPath, olderDir, _ := setupTwoMatchingWorkspaces(t)
+
+	const sessionID = "9bf61b07-aaaa-bbbb-cccc-000000000001"
+	writeSessionFile(t, olderDir, sessionID, "only-in-older")
+
+	p := NewProvider(VSCode)
+	session, err := p.GetAgentChatSession(projectPath, sessionID, false)
+	if err != nil {
+		t.Fatalf("GetAgentChatSession: %v", err)
+	}
+	if session.SessionID != sessionID {
+		t.Errorf("SessionID = %q, want %q", session.SessionID, sessionID)
+	}
+
+	// A session in no matching workspace must still error only after all are probed.
+	if _, err := p.GetAgentChatSession(projectPath, "does-not-exist", false); err == nil {
+		t.Error("expected error for unknown session ID, got nil")
+	} else if !strings.Contains(err.Error(), "session not found") {
+		t.Errorf("error = %q, want it to contain %q", err.Error(), "session not found")
+	}
+}
+
+// TestGetAgentChatSessions_AggregatesAcrossWorkspaces verifies sessions from every
+// matching workspace are returned, and a session ID present in both workspaces is
+// deduplicated with the newest workspace's copy winning.
+func TestGetAgentChatSessions_AggregatesAcrossWorkspaces(t *testing.T) {
+	projectPath, olderDir, newerDir := setupTwoMatchingWorkspaces(t)
+
+	writeSessionFile(t, olderDir, "session-a", "only-in-older")
+	writeSessionFile(t, olderDir, "session-b", "b-older-copy")
+	writeSessionFile(t, newerDir, "session-b", "b-newer-copy")
+	writeSessionFile(t, newerDir, "session-c", "only-in-newer")
+
+	p := NewProvider(VSCode)
+	sessions, err := p.GetAgentChatSessions(projectPath, false, nil)
+	if err != nil {
+		t.Fatalf("GetAgentChatSessions: %v", err)
+	}
+
+	byID := make(map[string]string) // sessionID -> RawData
+	for _, s := range sessions {
+		if _, dup := byID[s.SessionID]; dup {
+			t.Errorf("duplicate session ID in results: %q", s.SessionID)
+		}
+		byID[s.SessionID] = s.RawData
+	}
+
+	if len(sessions) != 3 {
+		t.Fatalf("got %d sessions, want 3 (IDs: %v)", len(sessions), byID)
+	}
+	for _, id := range []string{"session-a", "session-b", "session-c"} {
+		if _, ok := byID[id]; !ok {
+			t.Errorf("missing session %q in results", id)
+		}
+	}
+
+	// The duplicated session must come from the newest workspace.
+	if raw := byID["session-b"]; !strings.Contains(raw, "b-newer-copy") {
+		t.Errorf("session-b should come from the newest workspace, RawData = %s", raw)
+	}
+}
+
+// TestListAgentChatSessions_AggregatesAcrossWorkspaces verifies the lightweight list
+// aggregates across matching workspaces with the same dedup rule as the full read.
+func TestListAgentChatSessions_AggregatesAcrossWorkspaces(t *testing.T) {
+	projectPath, olderDir, newerDir := setupTwoMatchingWorkspaces(t)
+
+	writeSessionFile(t, olderDir, "session-a", "only-in-older")
+	writeSessionFile(t, olderDir, "session-b", "b-older-copy")
+	writeSessionFile(t, newerDir, "session-b", "b-newer-copy")
+	writeSessionFile(t, newerDir, "session-c", "only-in-newer")
+
+	p := NewProvider(VSCode)
+	metadataList, err := p.ListAgentChatSessions(projectPath)
+	if err != nil {
+		t.Fatalf("ListAgentChatSessions: %v", err)
+	}
+
+	ids := make(map[string]bool)
+	for _, m := range metadataList {
+		if ids[m.SessionID] {
+			t.Errorf("duplicate session ID in list: %q", m.SessionID)
+		}
+		ids[m.SessionID] = true
+	}
+
+	if len(metadataList) != 3 {
+		t.Fatalf("got %d sessions, want 3 (IDs: %v)", len(metadataList), ids)
+	}
+	for _, id := range []string{"session-a", "session-b", "session-c"} {
+		if !ids[id] {
+			t.Errorf("missing session %q in list", id)
+		}
+	}
+}
+
 func TestCollectCodeWorkspaceFolders(t *testing.T) {
 	base := canonicalTempDir(t)
 	relProject := filepath.Join(base, "rel-project")


### PR DESCRIPTION
Targets the `copilot-ide` branch (feeds #160), not `dev`.

## The fix

When more than one VS Code workspace maps to the same project, `GetAgentChatSessions` / `ListAgentChatSessions` currently keep only the **newest** matching workspace (`findWorkspaceForProject` → `selectNewestWorkspace`) and silently drop the rest. That loses chat history whenever the same repo is open in more than one workspace — e.g. a second VS Code window, or the repo opened both as a folder and via a `.code-workspace` file.

This changes the read paths to enumerate **all** matching workspaces (`FindWorkspacesForProject`) and merge their sessions (deduplicated; on a session-id collision the newest workspace wins). The single-newest selection is kept only where exactly one target is required (the reconstruction/resume write path).

## Tests

Adds provider unit tests that were missing: session loading, workspace matching (including the multi-workspace and `.code-workspace` cases), and agent-session conversion.

## Monitor accessors (dormant)

Also exports four thin wrappers — `Variants`, `ReadWorkspaceJSON`, `URIToPath`, `CollectCodeWorkspaceFolders` — used by the source-tree monitor's Copilot-IDE supervisor (#257). They have **no caller in this branch**; each carries a doc comment saying so and noting they go live once the monitor reaches `dev` and its `copilotide_monitor` build tag is dropped. Including them here means enabling that monitor later is a single tag flip rather than a separate provider PR at merge time. (If you'd rather not carry unused API, they're trivial to drop — say the word.)

## Notes

- `go build ./...`, `go vet ./...`, and `go test ./...` are green.
- No changelog entry: this improves the still-in-branch `copilotide` provider, so I left the release note to you rather than editing a dated section.
