### PR TITLE
Fix broken star history chart in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,4 +171,4 @@ Love SpecStory? Help others discover their AI coding memory upgrade by leaving a
 
 ## Star History
 
-![Star History Chart](https://api.star-history.com/svg?repos=specstoryai/getspecstory&type=Date)
+![Star History Chart](https://star-history.dera.page/svg?repos=specstoryai/getspecstory&type=Date)


### PR DESCRIPTION
The star history chart currently shows in the README was broken, so users could no longer see the repository's growth at a glance. This change points the chart at a working source so it displays correctly again.