### PR TITLE
Show who a session belongs to when a project is shared with a team

### DIFF
--- a/specstory-cli/pkg/cloud/auth.go
+++ b/specstory-cli/pkg/cloud/auth.go
@@ -565,14 +565,24 @@ func AuthenticatedAs() (username string, loginTime string) {
 		return "", ""
 	}
 
-	// Read auth data
-	if authData, err := readAuthData(authPath); err == nil {
-		if authData.CloudRefresh != nil {
-			return authData.CloudRefresh.As, authData.CloudRefresh.CreatedAt
-		}
+	// Read auth data. Both failure paths below return "" — the caller cannot act on the
+	// difference — but they are NOT the same condition, so say which one happened. A corrupt or
+	// unreadable auth.json otherwise looks identical to "no credentials stored", and callers
+	// that degrade quietly on an empty result (the resume browser drops owner attribution) give
+	// no clue why.
+	authData, err := readAuthData(authPath)
+	if err != nil {
+		slog.Debug("Could not read auth data for authenticated user info",
+			"path", authPath, "error", err)
+		return "", ""
+	}
+	if authData.CloudRefresh == nil {
+		slog.Debug("Auth data has no cloud refresh token; no user identity available",
+			"path", authPath)
+		return "", ""
 	}
 
-	return "", ""
+	return authData.CloudRefresh.As, authData.CloudRefresh.CreatedAt
 }
 
 // GetCloudToken returns the current access token for API calls.

--- a/specstory-cli/pkg/cloud/auth_test.go
+++ b/specstory-cli/pkg/cloud/auth_test.go
@@ -429,6 +429,10 @@ func TestAuthenticationCaching(t *testing.T) {
 // disables attribution entirely, so each path that produces one is exercised here rather than
 // left to be discovered as "the label just never shows up".
 func TestAuthenticatedAs(t *testing.T) {
+	// Every subtest calls ResetAuthCache() first. IsAuthenticated() memoises its answer in
+	// package-level state (authChecked), and AuthenticatedAs() returns early when it says no —
+	// so without a reset a stale result from an earlier test wins and the auth.json written
+	// here is never read. Verified: the suite fails under `go test -shuffle` without it.
 	authRelDir := filepath.Join(".specstory", "cli")
 
 	writeAuth := func(t *testing.T, home, contents string) {
@@ -447,6 +451,7 @@ func TestAuthenticatedAs(t *testing.T) {
 		`"createdAt":"2026-01-01T00:00:00Z","expiresAt":"2036-01-01T00:00:00Z"}}`
 
 	t.Run("returns the stored email", func(t *testing.T) {
+		ResetAuthCache()
 		home := t.TempDir()
 		testutil.SetHome(t, home)
 		writeAuth(t, home, valid)
@@ -461,6 +466,7 @@ func TestAuthenticatedAs(t *testing.T) {
 	})
 
 	t.Run("returns empty when nothing is stored", func(t *testing.T) {
+		ResetAuthCache()
 		testutil.SetHome(t, t.TempDir())
 
 		if email, _ := AuthenticatedAs(); email != "" {
@@ -472,6 +478,7 @@ func TestAuthenticatedAs(t *testing.T) {
 		// The path the reviewer flagged: a parse failure used to be swallowed silently and is
 		// now logged at debug. Behaviour is unchanged — still empty, so the UI stays
 		// conservative and simply shows no attribution.
+		ResetAuthCache()
 		home := t.TempDir()
 		testutil.SetHome(t, home)
 		writeAuth(t, home, "{ this is not json")

--- a/specstory-cli/pkg/cloud/auth_test.go
+++ b/specstory-cli/pkg/cloud/auth_test.go
@@ -423,3 +423,61 @@ func TestAuthenticationCaching(t *testing.T) {
 		t.Errorf("Expected true from cache even after removing auth file, got %v", result4)
 	}
 }
+
+// TestAuthenticatedAs covers the identity lookup behind owner attribution in the resume
+// browser. The empty-string returns matter as much as the successful one: an empty result
+// disables attribution entirely, so each path that produces one is exercised here rather than
+// left to be discovered as "the label just never shows up".
+func TestAuthenticatedAs(t *testing.T) {
+	authRelDir := filepath.Join(".specstory", "cli")
+
+	writeAuth := func(t *testing.T, home, contents string) {
+		t.Helper()
+		dir := filepath.Join(home, authRelDir)
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatalf("mkdir: %v", err)
+		}
+		if err := os.WriteFile(filepath.Join(dir, "auth.json"), []byte(contents), 0o600); err != nil {
+			t.Fatalf("write auth.json: %v", err)
+		}
+	}
+
+	// A refresh token far enough in the future that IsAuthenticated accepts it.
+	valid := `{"cloud_refresh":{"token":"t","as":"eric@specstory.com",` +
+		`"createdAt":"2026-01-01T00:00:00Z","expiresAt":"2036-01-01T00:00:00Z"}}`
+
+	t.Run("returns the stored email", func(t *testing.T) {
+		home := t.TempDir()
+		testutil.SetHome(t, home)
+		writeAuth(t, home, valid)
+
+		email, loginTime := AuthenticatedAs()
+		if email != "eric@specstory.com" {
+			t.Errorf("email = %q, want eric@specstory.com", email)
+		}
+		if loginTime != "2026-01-01T00:00:00Z" {
+			t.Errorf("loginTime = %q, want the createdAt", loginTime)
+		}
+	})
+
+	t.Run("returns empty when nothing is stored", func(t *testing.T) {
+		testutil.SetHome(t, t.TempDir())
+
+		if email, _ := AuthenticatedAs(); email != "" {
+			t.Errorf("email = %q, want empty", email)
+		}
+	})
+
+	t.Run("returns empty rather than panicking on a corrupt auth.json", func(t *testing.T) {
+		// The path the reviewer flagged: a parse failure used to be swallowed silently and is
+		// now logged at debug. Behaviour is unchanged — still empty, so the UI stays
+		// conservative and simply shows no attribution.
+		home := t.TempDir()
+		testutil.SetHome(t, home)
+		writeAuth(t, home, "{ this is not json")
+
+		if email, _ := AuthenticatedAs(); email != "" {
+			t.Errorf("email = %q, want empty", email)
+		}
+	})
+}

--- a/specstory-cli/pkg/cloud/resume_client.go
+++ b/specstory-cli/pkg/cloud/resume_client.go
@@ -100,8 +100,8 @@ type CloudProject struct {
 	OwnerName  string `json:"ownerName"`
 	OwnerEmail string `json:"ownerEmail"`
 
-	// Teammates holding their own copy of this repo, collapsed into this one entry by the
-	// server. 1 (or 0 on an older deployment) means nobody else has synced it.
+	// Team members holding their own copy of this repo (including you), collapsed into this one
+	// entry by the server. 1 (or 0 on an older deployment) means only you have synced it.
 	ContributorCount int `json:"contributorCount"`
 }
 

--- a/specstory-cli/pkg/cloud/resume_client.go
+++ b/specstory-cli/pkg/cloud/resume_client.go
@@ -60,7 +60,8 @@ type CloudSession struct {
 	// Owner attribution (Teams). A team-shared project's listings union your own rows with
 	// teammates' copies, so these say whose row this is. Absent on an older cloud deployment,
 	// and OwnerName/OwnerEmail are empty when the owner's profile has not been cached yet —
-	// so never branch on OwnerID alone, use ownerLabel() in pkg/cmd.
+	// so attribution/presence checks should require a displayable owner value instead of
+	// branching on OwnerID alone.
 	OwnerID    string `json:"ownerId"`
 	OwnerName  string `json:"ownerName"`
 	OwnerEmail string `json:"ownerEmail"`

--- a/specstory-cli/pkg/cloud/resume_client.go
+++ b/specstory-cli/pkg/cloud/resume_client.go
@@ -56,6 +56,14 @@ type CloudSession struct {
 	StartedAt string               `json:"startedAt"`
 	EndedAt   string               `json:"endedAt"`
 	Metadata  CloudSessionMetadata `json:"metadata"`
+
+	// Owner attribution (Teams). A team-shared project's listings union your own rows with
+	// teammates' copies, so these say whose row this is. Absent on an older cloud deployment,
+	// and OwnerName/OwnerEmail are empty when the owner's profile has not been cached yet —
+	// so never branch on OwnerID alone, use ownerLabel() in pkg/cmd.
+	OwnerID    string `json:"ownerId"`
+	OwnerName  string `json:"ownerName"`
+	OwnerEmail string `json:"ownerEmail"`
 }
 
 // CloudProject is a project (workspace) known to the cloud (server type: Project). Used to blend
@@ -83,6 +91,18 @@ type CloudProject struct {
 	LastUpdated  string         `json:"lastUpdated"`
 	SessionCount int            `json:"sessionCount"`
 	Sessions     []CloudSession `json:"sessions"` // populated only with ?resumable=true
+
+	// Owner attribution (Teams). A team-shared project's listings union your own rows with
+	// teammates' copies, so these say whose row this is. Absent on an older cloud deployment,
+	// and OwnerName/OwnerEmail are empty when the owner's profile has not been cached yet —
+	// so never branch on OwnerID alone, use ownerLabel() in pkg/cmd.
+	OwnerID    string `json:"ownerId"`
+	OwnerName  string `json:"ownerName"`
+	OwnerEmail string `json:"ownerEmail"`
+
+	// Teammates holding their own copy of this repo, collapsed into this one entry by the
+	// server. 1 (or 0 on an older deployment) means nobody else has synced it.
+	ContributorCount int `json:"contributorCount"`
 }
 
 // ResumeEligibility reports whether cross-machine cloud resume is available to the user, for

--- a/specstory-cli/pkg/cmd/session_tui.go
+++ b/specstory-cli/pkg/cmd/session_tui.go
@@ -165,8 +165,12 @@ type sessionTUI struct {
 	// the provider id ("claude") that dedup and the resume/reconstruct path key on.
 	cloudChecked  bool
 	cloudEligible bool
-	cloudPending  bool
-	cloudNudge    string
+	// Signed-in user's email, from the eligibility check. Drives the "is this row mine?"
+	// comparison behind ownerLabel; empty until that check lands, which correctly means no
+	// attribution renders yet.
+	viewerEmail  string
+	cloudPending bool
+	cloudNudge   string
 	// cloudAll holds the active project's cloud sessions SEPARATELY from m.all. They must not live
 	// in m.all: the background index warm and post-delete refresh both do `m.all = ListByProject()`,
 	// which would discard anything merged into it. Instead they're merged with m.all at filter time

--- a/specstory-cli/pkg/cmd/session_tui_browser.go
+++ b/specstory-cli/pkg/cmd/session_tui_browser.go
@@ -554,8 +554,12 @@ func (m sessionTUI) projectRow(p sessionindex.ProjectSummary, selected bool) str
 	}
 	chips := m.agentCountChips(p.AgentCounts)
 	when := relativeTime(p.LastActivity)
-	return cursor + cloudMark(p.IsCloud) + " " + renderName(projectDisplayName(p), selected, 30) + "  " +
+	row := cursor + cloudMark(p.IsCloud) + " " + renderName(projectDisplayName(p), selected, 30) + "  " +
 		chips + styDim.Render("  · "+when)
+	if by := ownerLabel(p.OwnerID, p.OwnerName, p.OwnerEmail, m.viewerEmail); by != "" {
+		row += styFaint.Render("  · " + by)
+	}
+	return row
 }
 
 // agentCountChips renders "claude 12 · codex 3" with colored agent tags.
@@ -920,16 +924,29 @@ func (m sessionTUI) globalRow(s sessionindex.Session, selected bool, snippet str
 
 	pad := m.agentColW - agentColMinWidth // widen with a long agent id so columns stay aligned
 
+	// Attribution is appended AFTER the label width maths rather than folded into it: the row
+	// budget is tuned for the title/snippet, and on a shared project every row would otherwise
+	// lose the same handful of columns whether or not it turned out to be a teammate's.
+	by := ownerLabel(s.OwnerID, s.OwnerName, s.OwnerEmail, m.viewerEmail)
+
 	if m.viewMode == "sparse" {
 		label := rowLabel(s, selected, snippet, m.lineWidth()-33-pad, m.lineWidth()-35-pad)
 		head := cursor + mark + " " + agent + "  " + styFaint.Render(proj) + "  " + label
-		sub := "       " + styFaint.Render(fmt.Sprintf("%s ago · %s", relativeTime(s.UpdatedAt), shortID(s.SessionID)))
+		meta := fmt.Sprintf("%s ago · %s", relativeTime(s.UpdatedAt), shortID(s.SessionID))
+		if by != "" {
+			meta += " · " + by
+		}
+		sub := "       " + styFaint.Render(meta)
 		return head + "\n" + sub
 	}
 
 	when := fmt.Sprintf("%-4s", relativeTime(s.UpdatedAt))
 	label := rowLabel(s, selected, snippet, m.lineWidth()-49-pad, m.lineWidth()-51-pad)
-	return cursor + mark + " " + agent + " " + styDim.Render(when) + "  " + styFaint.Render(proj) + "  " + label
+	row := cursor + mark + " " + agent + " " + styDim.Render(when) + "  " + styFaint.Render(proj) + "  " + label
+	if by != "" {
+		row += styFaint.Render("  · " + by)
+	}
+	return row
 }
 
 func sessionProject(s sessionindex.Session) string {

--- a/specstory-cli/pkg/cmd/session_tui_cloud.go
+++ b/specstory-cli/pkg/cmd/session_tui_cloud.go
@@ -235,7 +235,14 @@ func ownerLabel(ownerID, ownerName, ownerEmail, viewerEmail string) string {
 func cloudEligibilityCmd() tea.Cmd {
 	return func() tea.Msg {
 		loggedIn, pro := cloud.ResumeEligibility()
+		// The second return is the login TIME, not an error — AuthenticatedAs reports its own
+		// failures (see there). What it cannot know is that an empty email while signed in is
+		// meaningful HERE: it silently disables owner attribution on every cloud row, and the
+		// conservative ownerLabel rule makes that indistinguishable from "no teammates".
 		viewerEmail, _ := cloud.AuthenticatedAs()
+		if loggedIn && viewerEmail == "" {
+			slog.Debug("cloud resume: no viewer email; owner attribution disabled")
+		}
 		return cloudEligibilityMsg{loggedIn: loggedIn, pro: pro, viewerEmail: viewerEmail}
 	}
 }

--- a/specstory-cli/pkg/cmd/session_tui_cloud.go
+++ b/specstory-cli/pkg/cmd/session_tui_cloud.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log/slog"
 	"sort"
+	"strings"
 	"time"
 
 	tea "charm.land/bubbletea/v2"
@@ -179,6 +180,9 @@ func (m sessionTUI) upgradeCmd() tea.Cmd {
 type cloudEligibilityMsg struct {
 	loggedIn bool
 	pro      bool
+	// The signed-in user's email, for the "is this row mine?" comparison. Resolved here
+	// because it reads auth.json, which belongs off the UI thread alongside the network check.
+	viewerEmail string
 }
 
 // cloudSessionsMsg carries a completed cloud fetch for a project. sessions is already converted
@@ -198,11 +202,41 @@ type cloudProjectsMsg struct {
 	err       error
 }
 
+// ownerLabel returns the teammate to credit a cloud row to, or "" to credit nobody.
+//
+// Team-shared listings union your own rows with teammates' copies, so a row has to say when it
+// is not yours. The rule is deliberately CONSERVATIVE: label only when the row is positively
+// known to belong to someone else. Anything less certain renders nothing.
+//
+// Three real states would otherwise produce a wrong label:
+//   - the cloud deployment predates attribution and sends no owner fields at all;
+//   - the owner's profile has not been cached yet, so ownerEmail is empty and the row cannot be
+//     compared against the viewer;
+//   - the viewer's email is unknown (not signed in, or auth.json unreadable).
+//
+// Missing a teammate's label occasionally is far cheaper than telling someone their own session
+// belongs to a colleague. This mirrors ownerLabel() in the VS Code extension
+// (src/webview/lib/format.ts) — the two must agree, or the same session reads differently
+// depending on where you look at it.
+func ownerLabel(ownerID, ownerName, ownerEmail, viewerEmail string) string {
+	if ownerID == "" || ownerEmail == "" || viewerEmail == "" {
+		return ""
+	}
+	if strings.EqualFold(ownerEmail, viewerEmail) {
+		return ""
+	}
+	if n := strings.TrimSpace(ownerName); n != "" {
+		return n
+	}
+	return ownerEmail
+}
+
 // cloudEligibilityCmd runs the (networked) eligibility check off the UI thread.
 func cloudEligibilityCmd() tea.Cmd {
 	return func() tea.Msg {
 		loggedIn, pro := cloud.ResumeEligibility()
-		return cloudEligibilityMsg{loggedIn: loggedIn, pro: pro}
+		viewerEmail, _ := cloud.AuthenticatedAs()
+		return cloudEligibilityMsg{loggedIn: loggedIn, pro: pro, viewerEmail: viewerEmail}
 	}
 }
 
@@ -283,6 +317,9 @@ func cloudToSessions(cs []cloud.CloudSession, agentIDByName map[string]string) [
 			IsCloud:     true,
 			DeviceID:    c.Metadata.DeviceID,
 			MachineName: c.Metadata.MachineName,
+			OwnerID:     c.OwnerID,
+			OwnerName:   c.OwnerName,
+			OwnerEmail:  c.OwnerEmail,
 		})
 	}
 	return out
@@ -415,6 +452,9 @@ func cloudSearchHitsToSessions(
 			IsCloud:     true,
 			DeviceID:    h.Metadata.DeviceID,
 			MachineName: h.Metadata.MachineName,
+			OwnerID:     h.OwnerID,
+			OwnerName:   h.OwnerName,
+			OwnerEmail:  h.OwnerEmail,
 		})
 		if h.Snippet != "" {
 			snippets[sessionindex.FingerprintKey(agentID, h.ClientID)] = h.Snippet
@@ -516,6 +556,7 @@ func (m *sessionTUI) rebuildGlobalResults() {
 func (m sessionTUI) applyCloudEligibility(msg cloudEligibilityMsg) (tea.Model, tea.Cmd) {
 	m.cloudChecked = true
 	m.cloudEligible = msg.loggedIn && msg.pro
+	m.viewerEmail = msg.viewerEmail
 	switch {
 	case !msg.loggedIn:
 		m.cloudNudge = cloudNudgeLogin
@@ -736,6 +777,13 @@ func mergeCloudProjects(local []sessionindex.ProjectSummary, localKeys map[strin
 			AgentCounts:  make(map[string]int),
 			LastActivity: maxReal,
 			IsCloud:      true,
+			// Attribution rides only on cloud-ONLY projects. A project you also have locally is
+			// one you work in yourself, so labelling it with whichever teammate's copy the
+			// server picked as representative would be actively misleading.
+			OwnerID:          c.OwnerID,
+			OwnerName:        c.OwnerName,
+			OwnerEmail:       c.OwnerEmail,
+			ContributorCount: c.ContributorCount,
 		}
 		if ps.LastActivity == "" {
 			ps.LastActivity = maxSync

--- a/specstory-cli/pkg/cmd/session_tui_owner_test.go
+++ b/specstory-cli/pkg/cmd/session_tui_owner_test.go
@@ -1,0 +1,264 @@
+package cmd
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/specstoryai/getspecstory/specstory-cli/pkg/cloud"
+	"github.com/specstoryai/getspecstory/specstory-cli/pkg/sessionindex"
+)
+
+const viewer = "eric@specstory.com"
+
+// TestOwnerLabel pins the conservative attribution rule.
+//
+// A team-shared project's listings union your own rows with teammates' copies, so a row has to
+// say when it is not yours — but only when that is POSITIVELY known. Each silent case below is
+// indistinguishable from "this row is yours", and labelling your own session with a colleague's
+// name is a worse failure than showing nothing.
+//
+// This must stay in step with ownerLabel() in the VS Code extension
+// (src/webview/lib/format.ts): the same session should read the same way in both.
+func TestOwnerLabel(t *testing.T) {
+	tests := []struct {
+		name                           string
+		ownerID, ownerName, ownerEmail string
+		viewerEmail                    string
+		want                           string
+	}{
+		{
+			name:        "names the teammate who owns the row",
+			ownerID:     "user_greg",
+			ownerName:   "Greg",
+			ownerEmail:  "greg@specstory.com",
+			viewerEmail: viewer,
+			want:        "Greg",
+		},
+		{
+			name:        "falls back to the email when the profile has no name",
+			ownerID:     "user_greg",
+			ownerEmail:  "greg@specstory.com",
+			viewerEmail: viewer,
+			want:        "greg@specstory.com",
+		},
+		{
+			name:        "a whitespace-only name is not a name",
+			ownerID:     "user_greg",
+			ownerName:   "   ",
+			ownerEmail:  "greg@specstory.com",
+			viewerEmail: viewer,
+			want:        "greg@specstory.com",
+		},
+		{
+			name:        "credits nobody for your own row",
+			ownerID:     "user_me",
+			ownerName:   "Eric",
+			ownerEmail:  viewer,
+			viewerEmail: viewer,
+			want:        "",
+		},
+		{
+			name:        "matches your own row regardless of email casing",
+			ownerID:     "user_me",
+			ownerName:   "Eric",
+			ownerEmail:  "Eric@SpecStory.com",
+			viewerEmail: viewer,
+			want:        "",
+		},
+		{
+			// An older cloud deployment: the fields are simply not on the wire.
+			name:        "silent when the cloud sends no attribution",
+			viewerEmail: viewer,
+			want:        "",
+		},
+		{
+			// ownerId known, but the Clerk webhook has not backfilled a profile, so there is
+			// nothing to compare against the viewer.
+			name:        "silent when the owner has no cached profile",
+			ownerID:     "user_ghost",
+			viewerEmail: viewer,
+			want:        "",
+		},
+		{
+			// The dangerous shape: a name arrives without an email, so the row LOOKS
+			// attributable but cannot be compared against the viewer. Returning the name here
+			// is how you end up telling someone their own session belongs to a colleague.
+			name:        "silent when a name arrives without an email to compare",
+			ownerID:     "user_unknown",
+			ownerName:   "Eric",
+			viewerEmail: viewer,
+			want:        "",
+		},
+		{
+			// Not signed in, or auth.json unreadable — nothing is comparable.
+			name:       "silent when the viewer is unknown",
+			ownerID:    "user_greg",
+			ownerName:  "Greg",
+			ownerEmail: "greg@specstory.com",
+			want:       "",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := ownerLabel(tc.ownerID, tc.ownerName, tc.ownerEmail, tc.viewerEmail)
+			if got != tc.want {
+				t.Errorf("ownerLabel(%q, %q, %q, %q) = %q, want %q",
+					tc.ownerID, tc.ownerName, tc.ownerEmail, tc.viewerEmail, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestCloudToSessionsCarriesOwner verifies the browse listing's converter keeps attribution on
+// the row. The fields are carried RAW rather than pre-formatted, so the "is this mine?"
+// comparison happens once at render against the signed-in user.
+func TestCloudToSessionsCarriesOwner(t *testing.T) {
+	agentIDByName := map[string]string{"Claude Code": "claude"}
+
+	got := cloudToSessions([]cloud.CloudSession{
+		{
+			ClientID:   "aaa",
+			ProjectID:  "p1",
+			Name:       "n",
+			Metadata:   cloud.CloudSessionMetadata{AgentName: "Claude Code"},
+			OwnerID:    "user_greg",
+			OwnerName:  "Greg",
+			OwnerEmail: "greg@specstory.com",
+		},
+	}, agentIDByName)
+
+	if len(got) != 1 {
+		t.Fatalf("expected 1 session, got %d", len(got))
+	}
+	if got[0].OwnerID != "user_greg" || got[0].OwnerName != "Greg" ||
+		got[0].OwnerEmail != "greg@specstory.com" {
+		t.Errorf("owner not carried through: %+v", got[0])
+	}
+	if ownerLabel(got[0].OwnerID, got[0].OwnerName, got[0].OwnerEmail, viewer) != "Greg" {
+		t.Error("converted row should attribute to Greg for a different viewer")
+	}
+}
+
+// TestCloudSearchHitsCarryOwner does the same for the search path. Search collapses every
+// teammate's copy of a conversation into ONE hit, so which owner survives decides whose blob a
+// resume from that hit pulls — the label has to describe that copy, not an arbitrary one.
+func TestCloudSearchHitsCarryOwner(t *testing.T) {
+	agentIDByName := map[string]string{"Claude Code": "claude"}
+
+	sessions, _ := cloudSearchHitsToSessions([]cloud.CloudSearchHit{
+		{
+			CloudSession: cloud.CloudSession{
+				ClientID:   "aaa",
+				ProjectID:  "p1",
+				Metadata:   cloud.CloudSessionMetadata{AgentName: "Claude Code"},
+				OwnerID:    "user_greg",
+				OwnerName:  "Greg",
+				OwnerEmail: "greg@specstory.com",
+			},
+			Snippet: "hit",
+		},
+	}, agentIDByName)
+
+	if len(sessions) != 1 {
+		t.Fatalf("expected 1 session, got %d", len(sessions))
+	}
+	if sessions[0].OwnerEmail != "greg@specstory.com" {
+		t.Errorf("owner not carried through: %+v", sessions[0])
+	}
+}
+
+// TestMergeCloudProjectsAttribution covers the deliberate asymmetry: a cloud-ONLY project
+// carries its owner, a project you also have locally does not. A project present on this
+// machine is one you work in yourself, so labelling it with whichever teammate's copy the
+// server picked as representative would be actively misleading.
+func TestMergeCloudProjectsAttribution(t *testing.T) {
+	agentIDByName := map[string]string{"Claude Code": "claude"}
+
+	local := []sessionindex.ProjectSummary{
+		{
+			ProjectID:    "shared",
+			ProjectName:  "shared",
+			Sessions:     1,
+			LastActivity: "2026-08-01T10:00:00Z",
+			AgentCounts:  map[string]int{"claude": 1},
+		},
+	}
+
+	gregs := cloud.CloudSession{
+		ClientID:   "bbb",
+		Metadata:   cloud.CloudSessionMetadata{AgentName: "Claude Code"},
+		EndedAt:    "2026-08-02T10:00:00Z",
+		OwnerID:    "user_greg",
+		OwnerName:  "Greg",
+		OwnerEmail: "greg@specstory.com",
+	}
+
+	merged := mergeCloudProjects(local, nil, []cloud.CloudProject{
+		{
+			ID: "shared", Name: "shared", Sessions: []cloud.CloudSession{gregs},
+			OwnerID: "user_greg", OwnerName: "Greg", OwnerEmail: "greg@specstory.com",
+			ContributorCount: 2,
+		},
+		{
+			ID: "cloudonly", Name: "cloudonly", Sessions: []cloud.CloudSession{gregs},
+			OwnerID: "user_greg", OwnerName: "Greg", OwnerEmail: "greg@specstory.com",
+			ContributorCount: 2,
+		},
+	}, agentIDByName)
+
+	byID := map[string]sessionindex.ProjectSummary{}
+	for _, p := range merged {
+		byID[p.ProjectID] = p
+	}
+
+	cloudOnly, ok := byID["cloudonly"]
+	if !ok {
+		t.Fatal("cloud-only project missing from the merge")
+	}
+	if got := ownerLabel(cloudOnly.OwnerID, cloudOnly.OwnerName, cloudOnly.OwnerEmail, viewer); got != "Greg" {
+		t.Errorf("cloud-only project should attribute to Greg, got %q", got)
+	}
+	if cloudOnly.ContributorCount != 2 {
+		t.Errorf("contributorCount = %d, want 2", cloudOnly.ContributorCount)
+	}
+
+	shared, ok := byID["shared"]
+	if !ok {
+		t.Fatal("shared project missing from the merge")
+	}
+	if got := ownerLabel(shared.OwnerID, shared.OwnerName, shared.OwnerEmail, viewer); got != "" {
+		t.Errorf("a project held locally must not be attributed to a teammate, got %q", got)
+	}
+}
+
+// TestProjectRowRendersAttribution checks the label actually reaches the rendered row, and that
+// a row with nothing to say renders no trailing separator. Style codes are stripped by
+// comparing on substrings rather than exact output, which would pin the styling too.
+func TestProjectRowRendersAttribution(t *testing.T) {
+	m := sessionTUI{viewerEmail: viewer}
+
+	theirs := sessionindex.ProjectSummary{
+		ProjectID: "p1", ProjectName: "stoa", IsCloud: true,
+		LastActivity: "2026-08-02T10:00:00Z",
+		OwnerID:      "user_greg", OwnerName: "Greg", OwnerEmail: "greg@specstory.com",
+	}
+	if got := m.projectRow(theirs, false); !strings.Contains(got, "Greg") {
+		t.Errorf("teammate's project row should name Greg, got %q", got)
+	}
+
+	mine := theirs
+	mine.OwnerEmail = viewer
+	mine.OwnerName = "Eric"
+	got := m.projectRow(mine, false)
+	if strings.Contains(got, "Eric") {
+		t.Errorf("your own project row must not be attributed, got %q", got)
+	}
+
+	// An un-attributed row (older cloud deployment) must not render a dangling separator.
+	bare := theirs
+	bare.OwnerID, bare.OwnerName, bare.OwnerEmail = "", "", ""
+	if strings.HasSuffix(strings.TrimSpace(m.projectRow(bare, false)), "·") {
+		t.Error("un-attributed row should not end in a separator")
+	}
+}

--- a/specstory-cli/pkg/cmd/session_tui_owner_test.go
+++ b/specstory-cli/pkg/cmd/session_tui_owner_test.go
@@ -262,3 +262,57 @@ func TestProjectRowRendersAttribution(t *testing.T) {
 		t.Error("un-attributed row should not end in a separator")
 	}
 }
+
+// TestGlobalRowRendersAttribution covers the search rows, in both view modes.
+//
+// globalRow lays out sparse and dense differently — sparse puts the label on the row's second
+// (meta) line, dense appends it to the single line — so a regression can drop it from one while
+// the other still works. Both are asserted, along with the un-attributed case not leaving a
+// dangling separator behind.
+func TestGlobalRowRendersAttribution(t *testing.T) {
+	// agentColW at its historical minimum keeps the label width maths at pad=0, and lineWidth()
+	// falls back to 80 when width is unset — enough room that the title is not truncated into
+	// the assertions.
+	base := sessionTUI{viewerEmail: viewer, agentColW: agentColMinWidth}
+
+	theirs := sessionindex.Session{
+		ProjectID: "p1", ProjectName: "stoa", Agent: "claude",
+		SessionID: "aaaaaaaa", Name: "retry logic", UpdatedAt: "2026-08-02T10:00:00Z",
+		IsCloud: true,
+		OwnerID: "user_greg", OwnerName: "Greg", OwnerEmail: "greg@specstory.com",
+	}
+
+	mine := theirs
+	mine.OwnerID, mine.OwnerName, mine.OwnerEmail = "user_me", "Winifred", viewer
+
+	bare := theirs
+	bare.OwnerID, bare.OwnerName, bare.OwnerEmail = "", "", ""
+
+	for _, mode := range []string{"sparse", "dense"} {
+		t.Run(mode, func(t *testing.T) {
+			m := base
+			m.viewMode = mode
+
+			if got := m.globalRow(theirs, false, ""); !strings.Contains(got, "Greg") {
+				t.Errorf("teammate's search row should name Greg, got %q", got)
+			}
+
+			// "Winifred" appears nowhere else in the row, so a hit here is unambiguously the
+			// attribution label rather than an incidental substring.
+			if got := m.globalRow(mine, false, ""); strings.Contains(got, "Winifred") {
+				t.Errorf("your own search row must not be attributed, got %q", got)
+			}
+
+			// An older cloud deployment sends no owner fields; the row must not trail a
+			// separator with nothing after it.
+			got := m.globalRow(bare, false, "")
+			lines := strings.Split(got, "\n")
+			// stripANSI is the package's existing helper (skills_test.go) — a suffix assertion
+			// must see visible text, not a trailing style reset.
+			last := strings.TrimSpace(stripANSI(lines[len(lines)-1]))
+			if strings.HasSuffix(last, "·") {
+				t.Errorf("un-attributed row should not end in a separator, got %q", last)
+			}
+		})
+	}
+}

--- a/specstory-cli/pkg/sessionindex/store.go
+++ b/specstory-cli/pkg/sessionindex/store.go
@@ -712,9 +712,9 @@ type ProjectSummary struct {
 	// breakdown).
 	IsCloud bool
 
-	// Owner attribution for a team-shared project, on cloud-blended rows only. OwnerID names
-	// the teammate whose copy this entry describes; ContributorCount is how many teammates
-	// hold a copy the server collapsed into it.
+	// Owner attribution for a team-shared project, on cloud-only rows only. OwnerID names
+	// the teammate whose copy this entry describes; ContributorCount is how many team members
+	// (including you) hold a copy the server collapsed into it.
 	OwnerID          string
 	OwnerName        string
 	OwnerEmail       string

--- a/specstory-cli/pkg/sessionindex/store.go
+++ b/specstory-cli/pkg/sessionindex/store.go
@@ -82,6 +82,14 @@ type Session struct {
 	IsCloud     bool   // true = this row came from SpecStory Cloud, not the local index
 	DeviceID    string // cloud metadata.deviceId — stable machine id for the machine filter
 	MachineName string // cloud metadata.machineName — human machine label for the machine filter
+
+	// Owner attribution on a team-shared project: who synced this copy. Carried raw rather
+	// than pre-formatted so the "is this mine?" comparison happens once at render, against the
+	// signed-in user. Empty on local rows and on cloud rows from a deployment that predates
+	// attribution.
+	OwnerID    string
+	OwnerName  string
+	OwnerEmail string
 }
 
 // Fingerprint identifies an indexed session's freshness: the native file's size and
@@ -703,6 +711,14 @@ type ProjectSummary struct {
 	// rollups leave it false. AgentCounts is nil for these (the cloud list has no per-agent
 	// breakdown).
 	IsCloud bool
+
+	// Owner attribution for a team-shared project, on cloud-blended rows only. OwnerID names
+	// the teammate whose copy this entry describes; ContributorCount is how many teammates
+	// hold a copy the server collapsed into it.
+	OwnerID          string
+	OwnerName        string
+	OwnerEmail       string
+	ContributorCount int
 }
 
 // ListProjects returns one rolled-up summary per project, most recently active first.


### PR DESCRIPTION
### Changes

- **`pkg/cloud/resume_client.go`** — `CloudSession` and `CloudProject` gain `ownerId` /
  `ownerName` / `ownerEmail`; `CloudProject` also gets `contributorCount`. `CloudSearchHit`
  embeds `CloudSession`, so search picks them up for free.
- **`pkg/sessionindex/store.go`** — `Session` and `ProjectSummary` gain the same fields,
  alongside the existing cloud-only `IsCloud` / `DeviceID` / `MachineName` group. Not
  persisted to `sessions.db`, same as the rest of that group.
- **`pkg/cmd/session_tui_cloud.go`** — `ownerLabel()`, and the plumbing to carry owner fields
  through both converters and the project merge.
- **`pkg/cmd/session_tui.go` / `session_tui_browser.go`** — `sessionTUI.viewerEmail`, and the
  label rendered on project rows and search rows (both sparse and dense).

### The attribution rule is deliberately conservative

`ownerLabel` credits a teammate **only when the row is positively known to be theirs**. Four
states return `""` rather than guess:

| State | Why it can't be labelled |
|---|---|
| No owner fields on the wire | An older cloud deployment — indistinguishable from your own row |
| `ownerEmail` empty | Profile not cached yet, so nothing is comparable to the viewer |
| Name present, email absent | Looks attributable, isn't — the dangerous shape (see testing) |
| Viewer email unknown | Not signed in, or `auth.json` unreadable |

The permissive alternative — label whenever an owner exists — fails in a specific and bad way:
it tells you your own session belongs to a colleague. Missing a teammate's label occasionally
is much cheaper, and far easier to explain.

**This mirrors `ownerLabel()` in the VS Code extension** (`src/webview/lib/format.ts`). The
two must stay in step or the same session reads differently depending on where you look at it;
the Go test says so in a comment so the next person to touch either finds out.

### Two decisions worth a reviewer's attention

**Attribution rides on cloud-ONLY projects, not on projects you also hold locally.** A project
on this machine is one you work in yourself, so labelling it with whichever teammate's copy the
server picked as representative would be actively misleading. `TestMergeCloudProjectsAttribution`
pins both halves. This is the piece I'd most want a second opinion on.

**Owner fields are carried raw, not pre-formatted.** The converters copy `ownerId` /
`ownerName` / `ownerEmail` onto the index row and the "is this mine?" comparison happens once
at render against `m.viewerEmail`. That keeps the decision in one pure function instead of
threading the viewer's identity through three converters.

**Identity comes from `cloud.AuthenticatedAs()`**, resolved inside `cloudEligibilityCmd`
alongside the network check — it reads `auth.json`, which belongs off the UI thread — and
rides in on `cloudEligibilityMsg`. Until that lands, `viewerEmail` is empty, which correctly
means no attribution renders yet.

### Rendering

The label is appended **after** the row's width maths rather than folded into it. The label
budget is tuned for the title and snippet; folding attribution into it would cost every row the
same handful of columns on a shared project, whether or not that row turned out to be a
teammate's. An un-attributed row renders no trailing separator.

### Not included

Two product calls I've left open rather than deciding in code:

- **What resuming a teammate's session says.** It works today and mints a fresh session id, so
  the resumed copy lands in your own workspace — the question is whether that should announce
  itself.
- **The shared-repo delete path.** Deleting your copy leaves the teammate's, so the project
  reappears in the list. Fixing it means deciding what delete *means* on a shared project.

### Testing

`go build ./...`, `go vet ./...` and the full `go test ./...` are clean. New
`session_tui_owner_test.go` covers the rule (9 table cases), both converters, the merge
asymmetry, and that the label actually reaches a rendered row.

Mutation-tested, and the first pass **found a gap worth reporting**. Swapping in the permissive
rule initially failed only 1 of the 2 cases I expected: with no cached profile, both versions
happen to return empty, so the test couldn't distinguish them. I added the case that does — a
name arriving *without* an email, where the permissive rule returns the name and can therefore
credit your own session to a colleague. The mutant now fails both.

> `gofmt` flagged `session_tui.go` after the edit: inserting a field into an aligned struct
> block changes the required alignment. Fixed; `gofmt -l` is clean across `pkg/`.

### Deploy ordering

Safe to merge and ship independently. Go ignores unknown JSON fields, so this builds and runs
against the current production API — attribution simply renders nothing until the
`specstory-sync` PR is deployed and the owner fields appear on the wire. That's the first row
of the table above, working as designed.