### PR TITLE
ci: pin every GitHub Action to a commit sha

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,12 +31,12 @@ jobs:
       run:
         working-directory: specstory-cli
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-go@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version: '1.26.5'
           cache-dependency-path: specstory-cli/go.sum
-      - uses: golangci/golangci-lint-action@v9
+      - uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9.3.0
         with:
           version: latest
           working-directory: specstory-cli
@@ -48,8 +48,8 @@ jobs:
       run:
         working-directory: specstory-cli
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-go@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version: '1.26.5'
           cache-dependency-path: specstory-cli/go.sum
@@ -77,8 +77,8 @@ jobs:
       run:
         working-directory: specstory-cli
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-go@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version: '1.26.5'
           cache-dependency-path: specstory-cli/go.sum

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -25,12 +25,12 @@ jobs:
       security-events: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v4.37.3
+        uses: github/codeql-action/init@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
         with:
           languages: javascript
 
       - name: Analyze
-        uses: github/codeql-action/analyze@v4.37.3
+        uses: github/codeql-action/analyze@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3

--- a/.github/workflows/lore-release.yml
+++ b/.github/workflows/lore-release.yml
@@ -13,12 +13,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
 
       - name: Setup Node
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 22
 
@@ -65,7 +65,7 @@ jobs:
       # make_latest MUST stay false: the root install.sh resolves the CLI tarball from
       # GitHub releases/latest; a lore release taking "latest" would break the curl installer.
       - name: Create GitHub release
-        uses: softprops/action-gh-release@v3
+        uses: softprops/action-gh-release@efb35369e0ad2afab669f228072c1b0d510eae64 # v3.0.3
         with:
           name: lore-v${{ steps.version.outputs.version }}
           body: ${{ steps.notes.outputs.changelog }}

--- a/.github/workflows/lore-validate.yml
+++ b/.github/workflows/lore-validate.yml
@@ -22,10 +22,10 @@ jobs:
         working-directory: lore
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup Node
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 22
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,10 +13,10 @@ jobs:
     runs-on: ubuntu-latest
     environment: production
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
-      - uses: actions/setup-go@v7
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version: '1.26.5'
           cache-dependency-path: specstory-cli/go.sum
@@ -24,7 +24,7 @@ jobs:
         id: version
         run: echo "version=${GITHUB_REF_NAME#specstory-cli/}" >> $GITHUB_OUTPUT
 
-      - uses: goreleaser/goreleaser-action@v7
+      - uses: goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94 # v7.2.3
         with:
           version: "~> v2"
           args: release --clean --skip=validate
@@ -103,7 +103,7 @@ jobs:
     environment: production
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Extract version from tag
         id: version
@@ -127,7 +127,7 @@ jobs:
           echo "linux_x86_64=$(shasum -a 256 dist/SpecStoryCLI_Linux_x86_64.tar.gz | cut -d' ' -f1)" >> "$GITHUB_OUTPUT"
 
       - name: Checkout homebrew-tap
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: specstoryai/homebrew-tap
           token: ${{ secrets.HOMEBREW_TAP_TOKEN }}


### PR DESCRIPTION
Converts all 20 `uses:` references across the five workflow files from floating major tags (`@v7`) — plus `codeql-action`'s accidental exact-version pin from #265 — to full commit shas with a `# vX.Y.Z` comment.

**Pure pin-style change.** Each sha is the commit its previous tag resolves to as of today, so nothing that executes changes:

| Action | Was | Now resolves to |
|---|---|---|
| `actions/checkout` | `@v7` | `3d3c42e` v7.0.1 |
| `actions/setup-go` | `@v7` | `b7ad1da` v7.0.0 |
| `actions/setup-node` | `@v7` | `8207627` v7.0.0 |
| `softprops/action-gh-release` | `@v3` | `efb3536` v3.0.3 |
| `goreleaser/goreleaser-action` | `@v7` | `f06c13b` v7.2.3 |
| `golangci/golangci-lint-action` | `@v9` | `ba0d7d2` v9.3.0 |
| `github/codeql-action/{init,analyze}` | `@v4.37.3` | `e4fba86` v4.37.3 |

**Why.** A tag is a mutable label: its publisher, or anyone who compromises them, can re-point it and the next CI run executes the new code with the job's secrets (the `tj-actions/changed-files` incident). A sha is immutable. With sha pins, nothing in CI changes until dependabot opens a PR proposing the new sha — and that PR is where the provider-factory's DEPENDENCY-UPDATE workflow checks the sha actually belongs to the claimed release from the expected publisher. Dependabot handles sha pins natively and keeps the version comment current.

**Side effect.** Dependabot will recreate #281 (codeql-action 4.37.3 → 4.37.9) against the new pin style once this lands, and will start proposing sha updates for the other seven actions as they release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CEDDnLVXLKVFhwF9Bpzkvq
