### PR TITLE
SPE-78: Pi provider run/watch/reconstruct implementation

### DIFF
--- a/specstory-cli/README.md
+++ b/specstory-cli/README.md
@@ -38,7 +38,7 @@ The following coding agents are supported in the SpecStory CLI:
 | [Muse Code](https://github.com/facebook/muse-code)        | [musecode](pkg/providers/musecode/)             | JSONL       | `~/.local/share/muse/sessions/` |
 | [Pi](https://pi.dev)                                      | [piagent](pkg/providers/piagent/)               | JSONL       | `~/.pi/agent/sessions/`      |
 
-> **Note:** Pi support currently covers `sync`, `list`, `search`, `reindex`, `check`, and `detect`. `specstory run pi`, `specstory watch pi`, and cross-machine session resume are not yet supported.
+> **Note:** Pi support covers `sync`, `list`, `search`, `reindex`, `check`, `detect`, `run`, and `watch`, plus cross-provider session reconstruction (`specstory resume`). Pi resumes an existing session by exact id via `pi --session-id <id>`.
 
 Cursor IDE stores all of its conversations in a single global SQLite database (`state.vscdb`), located at `~/Library/Application Support/Cursor/User/globalStorage/` on macOS and `~/.config/Cursor/User/globalStorage/` on Linux. The `cursoride` provider reads that database directly (Cursor 3 is supported) and filters conversations to the current project via Cursor's workspace storage. Because an IDE has no exiting process to wrap, `specstory run cursoride` opens the project in Cursor and keeps auto-saving conversations until interrupted with `ctrl-c`.
 

--- a/specstory-cli/changelog.md
+++ b/specstory-cli/changelog.md
@@ -1,5 +1,11 @@
 # Specstory CLI Changelog
 
+## Unreleased
+
+### 📢 Announcements
+
+- The Pi coding agent (`pi`) now supports `specstory run pi` and `specstory watch pi`, so Pi sessions are saved to local markdown and the SpecStory Cloud live as you work, the same as the other supported agents. Pi is also now a cross-provider `specstory resume` target: you can resume any agent's session into Pi, and resume a Pi session into another agent. Pi continues an existing session by its exact id (`pi --session-id <id>`).
+
 ## v2.10.0 2026-08-17
 
 ### 📢 Announcements

--- a/specstory-cli/docs/PROVIDER-SPI.md
+++ b/specstory-cli/docs/PROVIDER-SPI.md
@@ -17,7 +17,7 @@ The SPI defines a standard interface that all agent providers must implement. Th
 | `muse` | Muse Code | `~/.local/share/muse/sessions/YYYY/MM/DD/<session-id>/session.jsonl` |
 | `pi` | Pi | `~/.pi/agent/sessions/--<encoded-cwd>--/<timestamp>_<uuid>.jsonl` |
 
-> The `pi` provider currently implements sync/list/search/reindex/check/detect; `run`, `watch`, and session reconstruction return descriptive "not yet supported" errors.
+> The `pi` provider implements sync/list/search/reindex/check/detect, `run`, `watch`, and native session reconstruction (`ReconstructSession`/`NativeSessionPath`), so it can be a cross-provider `resume` target.
 
 ## Quick Start: Implementing a New Provider
 

--- a/specstory-cli/pkg/cmd/resume_test.go
+++ b/specstory-cli/pkg/cmd/resume_test.go
@@ -250,7 +250,7 @@ func (f *fakeProvider) ListAllAgentChatSessions() ([]spi.GlobalSessionRef, error
 // invalid reconstruction target.
 func TestSupportsReconstruction(t *testing.T) {
 	registry := factory.GetRegistry()
-	for id, want := range map[string]bool{"claude": true, "codex": true, "antigravity": false} {
+	for id, want := range map[string]bool{"claude": true, "codex": true, "pi": true, "antigravity": false} {
 		prov, err := registry.Get(id)
 		if err != nil {
 			t.Fatalf("registry.Get(%q): %v", id, err)

--- a/specstory-cli/pkg/providers/piagent/piagent_exec.go
+++ b/specstory-cli/pkg/providers/piagent/piagent_exec.go
@@ -1,0 +1,86 @@
+package piagent
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+
+	"log/slog"
+)
+
+// resumeFlag is how pi continues an existing session on the command line:
+// `pi --session-id <id>`. This is a flag append (like Claude Code's --resume),
+// not a subcommand (like Codex's `codex resume <id>`), so spi.EnsureResumeArgs
+// is not used here.
+//
+// Verified empirically against pi v0.84.4: `--session-id <id>` matches the exact
+// project session id (the header `id` our parser reads and our serializer
+// writes), reopens the SAME conversation, and appends to the same session file.
+// The alternative `--session <path|id>` was rejected as the resume flag because
+// it is selection/partial-UUID driven and does not create-if-missing; a caller
+// resuming a specific id wants an exact match. `--session-id` additionally
+// creates the session if missing, which is harmless for our flow (the
+// reconstructed file is written to NativeSessionPath before pi launches, so the
+// exact id already exists on disk).
+const resumeFlag = "--session-id"
+
+// parsePiRunCommand splits a custom run command into the pi binary and its base
+// args (reusing parsePiCommand for the SplitCommandLine quoting + tilde
+// expansion), then appends pi's resume flag when a session id is provided. An
+// empty custom command falls back to the default `pi` binary. resumeSessionID is
+// expected pre-trimmed by ExecAgentAndWatch; the guard here means a direct
+// caller cannot append an empty `--session-id`.
+func parsePiRunCommand(customCommand string, resumeSessionID string) (string, []string) {
+	cmd, args := parsePiCommand(customCommand)
+	if id := strings.TrimSpace(resumeSessionID); id != "" {
+		args = append(args, resumeFlag, id)
+	}
+	return cmd, args
+}
+
+// getDefaultPiCommand returns the default pi binary. Unlike Claude Code
+// (~/.local/bin, npm) and Codex (Homebrew, npm), pi ships as a single `pi` on
+// the PATH with no per-manager install locations worth probing, so a plain PATH
+// lookup via exec.Command is the safe default and keeps the code DRY.
+func getDefaultPiCommand() string {
+	return defaultCmd
+}
+
+// ExecutePi runs the pi CLI with interactive TTY passthrough: stdin/stdout/stderr
+// are inherited from the parent so pi shares the terminal and Ctrl-C reaches it
+// (no explicit os/signal handling, same as the sibling providers). On a non-zero
+// child exit it propagates pi's exit code via os.Exit so the status flows
+// through unchanged; other wait errors are wrapped and returned.
+func ExecutePi(customCommand string, resumeSessionID string) error {
+	piCmd, args := parsePiRunCommand(customCommand, resumeSessionID)
+
+	if strings.TrimSpace(resumeSessionID) != "" {
+		slog.Info("ExecutePi: resuming session", "sessionId", resumeSessionID)
+	}
+
+	cmd := exec.Command(piCmd, args...)
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	slog.Info("ExecutePi: starting pi process", "command", piCmd)
+	if err := cmd.Start(); err != nil {
+		return fmt.Errorf("failed to start pi: %w", err)
+	}
+
+	slog.Info("ExecutePi: waiting for pi to exit")
+	if err := cmd.Wait(); err != nil {
+		// A non-zero exit is normal for an interactive CLI; propagate pi's own
+		// exit code so the caller's shell sees it, matching the sibling providers.
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			exitCode := exitErr.ExitCode()
+			slog.Info("ExecutePi: pi exited", "exitCode", exitCode)
+			os.Exit(exitCode)
+		}
+		return fmt.Errorf("pi execution failed: %w", err)
+	}
+
+	slog.Info("ExecutePi: pi exited normally", "exitCode", 0)
+	return nil
+}

--- a/specstory-cli/pkg/providers/piagent/piagent_exec_test.go
+++ b/specstory-cli/pkg/providers/piagent/piagent_exec_test.go
@@ -1,0 +1,94 @@
+package piagent
+
+import (
+	"testing"
+)
+
+// TestParsePiRunCommand covers the command split (quoting, tilde) and the resume
+// flag append (`--session-id <id>`). ExecutePi itself is not unit-tested: it
+// execs a real binary and calls os.Exit, so coverage goes through this parser,
+// exactly as claudecode does.
+func TestParsePiRunCommand(t *testing.T) {
+	home := expandTilde("~/x") // resolve once so the tilde case is host-independent
+
+	tests := []struct {
+		name            string
+		customCommand   string
+		resumeSessionID string
+		expectedCmd     string
+		expectedArgs    []string
+	}{
+		{
+			name:         "empty command returns default pi, no args",
+			expectedCmd:  "pi",
+			expectedArgs: nil,
+		},
+		{
+			name:          "whitespace-only command returns default pi",
+			customCommand: "   ",
+			expectedCmd:   "pi",
+			expectedArgs:  nil,
+		},
+		{
+			name:          "command with args",
+			customCommand: "pi --provider openai --model gpt-4o",
+			expectedCmd:   "pi",
+			expectedArgs:  []string{"--provider", "openai", "--model", "gpt-4o"},
+		},
+		{
+			name:          "quoted argument containing spaces",
+			customCommand: `pi --system-prompt "you are helpful"`,
+			expectedCmd:   "pi",
+			expectedArgs:  []string{"--system-prompt", "you are helpful"},
+		},
+		{
+			name:          "tilde in binary path is expanded",
+			customCommand: "~/x --model gpt-4o",
+			expectedCmd:   home,
+			expectedArgs:  []string{"--model", "gpt-4o"},
+		},
+		{
+			name:            "resume id with empty command appends session-id flag",
+			resumeSessionID: "01a067f7-2950-7155-b562-8297e73e3428",
+			expectedCmd:     "pi",
+			expectedArgs:    []string{"--session-id", "01a067f7-2950-7155-b562-8297e73e3428"},
+		},
+		{
+			name:            "resume id with custom command appends after args",
+			customCommand:   "pi --model gpt-4o",
+			resumeSessionID: "sess-1",
+			expectedCmd:     "pi",
+			expectedArgs:    []string{"--model", "gpt-4o", "--session-id", "sess-1"},
+		},
+		{
+			name:            "resume id is trimmed before append",
+			resumeSessionID: "  sess-2  ",
+			expectedCmd:     "pi",
+			expectedArgs:    []string{"--session-id", "sess-2"},
+		},
+		{
+			name:            "whitespace-only resume id appends nothing",
+			customCommand:   "pi",
+			resumeSessionID: "   ",
+			expectedCmd:     "pi",
+			expectedArgs:    nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmd, args := parsePiRunCommand(tt.customCommand, tt.resumeSessionID)
+			if cmd != tt.expectedCmd {
+				t.Errorf("cmd = %q, want %q", cmd, tt.expectedCmd)
+			}
+			if len(args) != len(tt.expectedArgs) {
+				t.Fatalf("args = %v, want %v", args, tt.expectedArgs)
+			}
+			for i := range args {
+				if args[i] != tt.expectedArgs[i] {
+					t.Errorf("args[%d] = %q, want %q", i, args[i], tt.expectedArgs[i])
+				}
+			}
+		})
+	}
+}

--- a/specstory-cli/pkg/providers/piagent/provider.go
+++ b/specstory-cli/pkg/providers/piagent/provider.go
@@ -16,15 +16,13 @@ import (
 	"github.com/specstoryai/getspecstory/specstory-cli/pkg/analytics"
 	"github.com/specstoryai/getspecstory/specstory-cli/pkg/log"
 	"github.com/specstoryai/getspecstory/specstory-cli/pkg/spi"
-	"github.com/specstoryai/getspecstory/specstory-cli/pkg/spi/schema"
 )
 
 const (
-	providerID    = "pi"
-	providerName  = "Pi"
-	defaultCmd    = "pi"
-	versionFlag   = "--version"
-	notYetSupport = "pi: %s not yet supported for the pi provider (v1 supports sync, list, search, reindex, check, and detect)"
+	providerID   = "pi"
+	providerName = "Pi"
+	defaultCmd   = "pi"
+	versionFlag  = "--version"
 )
 
 // Compile-time assertion that Provider satisfies the full spi.Provider contract.
@@ -54,7 +52,7 @@ func parsePiCommand(customCommand string) (string, []string) {
 			return expandTilde(parts[0]), parts[1:]
 		}
 	}
-	return defaultCmd, nil
+	return getDefaultPiCommand(), nil
 }
 
 // classifyCheckError buckets a Check failure for messaging and analytics,
@@ -172,31 +170,57 @@ func (p *Provider) DetectAgent(projectPath string, helpOutput bool) bool {
 	return false
 }
 
-// ExecAgentAndWatch is the `specstory run pi` wrapper — out of v1 scope.
-func (p *Provider) ExecAgentAndWatch(_ string, _ string, _ string, _ bool, _ func(*spi.AgentChatSession)) error {
-	return fmt.Errorf(notYetSupport, "ExecAgentAndWatch (specstory run pi)")
+// ExecAgentAndWatch runs pi interactively (`specstory run pi`) while watching the
+// project's session directory, invoking sessionCallback as pi writes JSONL so
+// markdown generation and cloud sync happen live. It blocks until pi exits.
+func (p *Provider) ExecAgentAndWatch(projectPath string, customCommand string, resumeSessionID string, debugRaw bool, sessionCallback func(*spi.AgentChatSession)) error {
+	// pi resumes by exact session id (`pi --session-id <id>`); the id is pi's
+	// header `id`, an arbitrary string, so we only trim + reject empty here and
+	// let pi surface its own id-shape validation rather than second-guessing it
+	// (unlike Claude Code, whose ids are strictly UUIDs).
+	if resumeSessionID != "" {
+		resumeSessionID = strings.TrimSpace(resumeSessionID)
+		if resumeSessionID == "" {
+			return fmt.Errorf("pi: resume session id is empty after trimming whitespace")
+		}
+		slog.Info("pi: resuming session", "sessionId", resumeSessionID)
+	}
+
+	SetWatcherCallback(sessionCallback)
+	defer ClearWatcherCallback()
+	SetWatcherDebugRaw(debugRaw)
+
+	// Start the watcher before launching pi so nothing pi writes is missed.
+	// Non-fatal (same as the sibling providers): a failed watcher must not stop
+	// the user's interactive pi session.
+	if err := WatchForProjectDir(projectPath); err != nil {
+		slog.Error("pi: failed to start session watcher", "error", err)
+	}
+
+	err := ExecutePi(customCommand, resumeSessionID)
+	StopWatcher()
+	if err != nil {
+		return fmt.Errorf("pi execution failed: %w", err)
+	}
+	return nil
 }
 
-// WatchAgent is live watch — out of v1 scope.
-func (p *Provider) WatchAgent(_ context.Context, _ string, _ bool, _ func(*spi.AgentChatSession)) error {
-	return fmt.Errorf(notYetSupport, "WatchAgent")
-}
+// WatchAgent watches for pi session activity (`specstory watch pi`) and invokes
+// sessionCallback with each parsed session. It does not launch pi; it blocks
+// until the context is cancelled.
+func (p *Provider) WatchAgent(ctx context.Context, projectPath string, debugRaw bool, sessionCallback func(*spi.AgentChatSession)) error {
+	SetWatcherCallback(sessionCallback)
+	defer ClearWatcherCallback()
+	SetWatcherDebugRaw(debugRaw)
 
-// ReconstructSession is out of v1 scope; pi has no native serializer yet.
-func (p *Provider) ReconstructSession(_ *schema.SessionData, _ spi.ReconstructOptions) (*spi.ReconstructedSession, error) {
-	return nil, errors.Join(spi.ErrReconstructionUnsupported, fmt.Errorf(notYetSupport, "ReconstructSession"))
-}
+	if err := WatchForProjectDir(projectPath); err != nil {
+		slog.Error("pi: failed to start session watcher", "error", err)
+		return fmt.Errorf("pi: failed to start watcher: %w", err)
+	}
 
-// NativeSessionPath is out of v1 scope (no native serializer).
-func (p *Provider) NativeSessionPath(_ string, _ string) (string, error) {
-	return "", errors.Join(spi.ErrReconstructionUnsupported, fmt.Errorf(notYetSupport, "NativeSessionPath"))
-}
-
-// SupportsReconstruction reports false: ReconstructSession/NativeSessionPath
-// above are out of v1 scope, so this provider must never be offered as a
-// cross-agent or cloud resume target until a native serializer exists.
-func (p *Provider) SupportsReconstruction() bool {
-	return false
+	<-ctx.Done()
+	StopWatcher()
+	return ctx.Err()
 }
 
 // trackCheckSuccess emits the standard install-check success analytics event,

--- a/specstory-cli/pkg/providers/piagent/reconstruct.go
+++ b/specstory-cli/pkg/providers/piagent/reconstruct.go
@@ -1,0 +1,167 @@
+package piagent
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/specstoryai/getspecstory/specstory-cli/pkg/spi"
+	"github.com/specstoryai/getspecstory/specstory-cli/pkg/spi/schema"
+)
+
+const (
+	// reconstructedPiProvider / reconstructedPiModel are placeholder labels stamped
+	// on reconstructed assistant records. They are historical display values only —
+	// on resume pi uses its own configured provider/model for the next turn.
+	// Verified against a real pi v0.84.4 assistant entry: provider/model/api/
+	// stopReason are display metadata the loader tolerates as arbitrary strings, so
+	// a constant placeholder is safe and no `usage` block is required.
+	reconstructedPiProvider = "specstory"
+	reconstructedPiModel    = "claude-opus-4-8"
+
+	// piHeaderVersion is the integer format version pi stamps on a v3 session
+	// header. Confirmed by reading a pi v0.84.4 session file: {"type":"session",
+	// "version":3,...}. The read side maps header.Version>0 → "v3".
+	piHeaderVersion = 3
+
+	// reconstructedPiStopReason mirrors the stopReason pi writes on a completed
+	// assistant turn (observed "stop"). The loader ignores it for records that
+	// carry text content, but matching the real value keeps the file faithful.
+	reconstructedPiStopReason = "stop"
+)
+
+// ReconstructSession rebuilds a native pi JSONL v3 session from the neutral
+// SessionData so `pi --session-id <id>` can continue the conversation.
+//
+// The forward parser collapses pi's id/parentId tree to the active leaf path and
+// folds tool calls and thinking into agent text (via FlattenSessionData), so
+// reconstruction emits a fresh, strictly linear parentId chain of plain
+// user/assistant text entries under a fresh v3 header. It is NOT a structural
+// round-trip and does not replay structured toolCall/toolResult entries — the
+// fidelity bar is "valid to pi's own loader, conveys the gist". See
+// docs/SESSION-PORTABILITY.md.
+func (p *Provider) ReconstructSession(data *schema.SessionData, opts spi.ReconstructOptions) (*spi.ReconstructedSession, error) {
+	turns, err := spi.PrepareTurns(data, opts)
+	if err != nil {
+		return nil, err
+	}
+	cwd := spi.ResolveWorkspaceRoot(opts, data)
+
+	newID := uuid.NewString()
+	base := time.Now().UTC()
+
+	var buf bytes.Buffer
+	enc := json.NewEncoder(&buf)
+	// Preserve <, >, & in conversation/markdown text rather than \u-escaping them.
+	enc.SetEscapeHTML(false)
+
+	// Line 0: the session header (type "session", version 3, no id/parentId).
+	// specstorySourceSessionId is provenance — pi's sessionHeader decode ignores
+	// unknown fields, mirroring how the sibling providers stamp the source id.
+	header := map[string]interface{}{
+		"type":                     entrySession,
+		"version":                  piHeaderVersion,
+		"id":                       newID,
+		"timestamp":                spi.RFC3339Millis(base),
+		"cwd":                      cwd,
+		"specstorySourceSessionId": data.SessionID,
+	}
+	if err := enc.Encode(header); err != nil {
+		return nil, fmt.Errorf("pi: encoding session header: %w", err)
+	}
+
+	// Lines 1..N: one "message" entry per flattened turn, threaded into a linear
+	// parentId chain (first entry parentId:null, each next → previous entry id).
+	// A fresh forward-only chain of UUIDs cannot form a cycle, so no write-side
+	// cycle guard is needed (the read-side walkToRoot still guards on load).
+	var prevID *string
+	for i, turn := range turns {
+		recID := uuid.NewString()
+		ts := spi.RFC3339Millis(base.Add(time.Duration(i+1) * time.Second))
+
+		rec := map[string]interface{}{
+			"type":      entryMessage,
+			"id":        recID,
+			"parentId":  prevID, // nil pointer → JSON null for the first entry
+			"timestamp": ts,
+			"message":   reconstructMessage(turn),
+		}
+		if err := enc.Encode(rec); err != nil {
+			return nil, fmt.Errorf("pi: encoding reconstructed message: %w", err)
+		}
+
+		id := recID
+		prevID = &id
+	}
+
+	return &spi.ReconstructedSession{
+		SessionID: newID,
+		Filename:  piNativeFilename(base, newID),
+		Content:   buf.Bytes(),
+	}, nil
+}
+
+// reconstructMessage builds the wrapped `message` payload for a flattened turn.
+// User content is emitted as the bare-string form (pi's read side accepts a
+// string or an array; the string is the simplest valid shape). Assistant content
+// is the {type:text} block array pi writes.
+func reconstructMessage(turn spi.Turn) map[string]interface{} {
+	if turn.Role == schema.RoleUser {
+		return map[string]interface{}{
+			"role":    "user",
+			"content": turn.Text,
+		}
+	}
+	return map[string]interface{}{
+		"role":       "assistant",
+		"content":    []map[string]interface{}{{"type": "text", "text": turn.Text}},
+		"provider":   reconstructedPiProvider,
+		"model":      reconstructedPiModel,
+		"api":        "",
+		"stopReason": reconstructedPiStopReason,
+	}
+}
+
+// piNativeFilename reproduces pi's own `<timestamp>_<id>.jsonl` session filename:
+// the header's RFC 3339 millisecond timestamp with ':' and '.' replaced by '-'
+// (filesystem-safe, no ':'), then '_' and the session id. Observed real file:
+// 2026-09-03T15-50-46-352Z_01a067f7-...jsonl, whose id equals the header id.
+func piNativeFilename(base time.Time, id string) string {
+	safeTS := strings.NewReplacer(":", "-", ".", "-").Replace(spi.RFC3339Millis(base))
+	return fmt.Sprintf("%s_%s.jsonl", safeTS, id)
+}
+
+// NativeSessionPath returns where a reconstructed session file belongs in pi's
+// store: <sessions-root>/--<encoded-cwd>--/<filename> for the default layout, or
+// <override>/<filename> for the flat PI_CODING_AGENT_SESSION_DIR layout. The
+// directory is not required to exist — the caller (`specstory resume`) creates it
+// and writes the file.
+func (p *Provider) NativeSessionPath(projectPath string, filename string) (string, error) {
+	dir, err := resolvePiSessionDir(projectPath)
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, filename), nil
+}
+
+// resolvePiSessionDir returns the directory a reconstructed pi session belongs
+// in, reusing ProjectSessionDir — the same encoder the read side uses — so a
+// reconstructed file lands in the exact directory pi will look in. It resolves
+// without requiring the directory to exist and handles both the default
+// encoded-cwd layout and the flat override, keeping the write side free of any
+// filesystem side effects.
+func resolvePiSessionDir(projectPath string) (string, error) {
+	return ProjectSessionDir(projectPath)
+}
+
+// SupportsReconstruction reports true: pi now has a native serializer (see
+// ReconstructSession/NativeSessionPath above), so it can be a cross-provider
+// resume target.
+func (p *Provider) SupportsReconstruction() bool {
+	return true
+}

--- a/specstory-cli/pkg/providers/piagent/reconstruct_test.go
+++ b/specstory-cli/pkg/providers/piagent/reconstruct_test.go
@@ -1,0 +1,229 @@
+package piagent
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/specstoryai/getspecstory/specstory-cli/pkg/spi"
+	"github.com/specstoryai/getspecstory/specstory-cli/pkg/spi/schema"
+)
+
+func strptr(s string) *string { return &s }
+
+// reconstructSampleData exercises every flatten path: user text, agent text,
+// agent thinking, and a tool call carrying both a summary and formatted markdown.
+func reconstructSampleData() *schema.SessionData {
+	summary := "Tool use: **bash** `ls`"
+	fm := "```\nhello.c\nhello\n```"
+	return &schema.SessionData{
+		SchemaVersion: "1.0",
+		Provider:      schema.ProviderInfo{ID: providerID, Name: providerName, Version: "v3"},
+		SessionID:     "orig-pi-123",
+		CreatedAt:     "2026-06-17T10:00:00.000Z",
+		WorkspaceRoot: "/tmp/proj",
+		Exchanges: []schema.Exchange{
+			{
+				ExchangeID: "orig-pi-123:0",
+				Messages: []schema.Message{
+					{Role: schema.RoleUser, Content: []schema.ContentPart{{Type: schema.ContentTypeText, Text: "Create a hello world in D."}}},
+					{Role: schema.RoleAgent, Content: []schema.ContentPart{{Type: schema.ContentTypeText, Text: "Adding hello.d."}}},
+					{Role: schema.RoleAgent, Content: []schema.ContentPart{{Type: schema.ContentTypeThinking, Text: "Check for a compiler."}}},
+					{Role: schema.RoleAgent, Tool: &schema.ToolInfo{Name: "bash", Type: schema.ToolTypeShell, Summary: strptr(summary), FormattedMarkdown: strptr(fm)}},
+					{Role: schema.RoleAgent, Content: []schema.ContentPart{{Type: schema.ContentTypeText, Text: "Created hello.d."}}},
+				},
+			},
+		},
+	}
+}
+
+// parsePiJSONL splits reconstructed content into per-line maps. It uses a
+// bufio.Reader (not bufio.Scanner) with unbounded line size because pi session
+// lines can legitimately exceed the 16 MB Scanner cap; reconstructed lines are
+// small, but mirroring the read side's reader keeps the helper honest.
+func parsePiJSONL(t *testing.T, content []byte) []map[string]any {
+	t.Helper()
+	var records []map[string]any
+	reader := bufio.NewReader(bytes.NewReader(content))
+	for {
+		line, err := reader.ReadString('\n')
+		trimmed := strings.TrimSpace(line)
+		if trimmed != "" {
+			var m map[string]any
+			if uErr := json.Unmarshal([]byte(trimmed), &m); uErr != nil {
+				t.Fatalf("invalid JSONL line %q: %v", trimmed, uErr)
+			}
+			records = append(records, m)
+		}
+		if err != nil {
+			break // io.EOF or a read error ends the scan
+		}
+	}
+	return records
+}
+
+// TestReconstructSession_RoundTrip reconstructs to native pi v3 JSONL, re-parses
+// through pi's own ParseSession, and asserts the flattened transcript is
+// preserved turn-for-turn — proving pi's reader accepts our output.
+func TestReconstructSession_RoundTrip(t *testing.T) {
+	data := reconstructSampleData()
+	expected := spi.FlattenSessionData(data, "")
+
+	out, err := NewProvider().ReconstructSession(data, spi.ReconstructOptions{WorkspaceRoot: "/tmp/proj"})
+	if err != nil {
+		t.Fatalf("ReconstructSession: %v", err)
+	}
+	if out.SessionID == "" {
+		t.Fatal("expected a fresh session ID")
+	}
+	// Filename shape: <timestamp>_<uuid>.jsonl, ending with the session id.
+	if !strings.HasSuffix(out.Filename, "_"+out.SessionID+".jsonl") {
+		t.Errorf("filename %q should end with _<sessionID>.jsonl", out.Filename)
+	}
+	if strings.ContainsAny(out.Filename, ":") {
+		t.Errorf("filename %q must be filesystem-safe (no ':')", out.Filename)
+	}
+
+	// Re-parse the reconstructed bytes through pi's own read path.
+	dir := t.TempDir()
+	path := filepath.Join(dir, out.Filename)
+	if wErr := os.WriteFile(path, out.Content, 0o600); wErr != nil {
+		t.Fatalf("writing reconstructed file: %v", wErr)
+	}
+	regenerated, err := ParseSession(path)
+	if err != nil {
+		t.Fatalf("ParseSession of reconstructed file: %v", err)
+	}
+
+	actual := spi.FlattenSessionData(regenerated, "")
+	if len(actual) != len(expected) {
+		t.Fatalf("round-trip produced %d turns, want %d\n got: %+v\nwant: %+v", len(actual), len(expected), actual, expected)
+	}
+	for i := range expected {
+		if actual[i] != expected[i] {
+			t.Errorf("turn %d mismatch:\n got: %+v\nwant: %+v", i, actual[i], expected[i])
+		}
+	}
+}
+
+// TestReconstructSession_Chain asserts the header + strictly-linear parentId
+// chain, and that feeding the message entries through pi's own walkToRoot
+// terminates and yields every turn in order (no accidental cycle).
+func TestReconstructSession_Chain(t *testing.T) {
+	data := reconstructSampleData()
+	out, err := NewProvider().ReconstructSession(data, spi.ReconstructOptions{WorkspaceRoot: "/tmp/proj"})
+	if err != nil {
+		t.Fatalf("ReconstructSession: %v", err)
+	}
+
+	records := parsePiJSONL(t, out.Content)
+	if len(records) < 2 {
+		t.Fatalf("expected a header + at least one message, got %d records", len(records))
+	}
+
+	// Line 0 is the session header.
+	header := records[0]
+	if header["type"] != entrySession {
+		t.Errorf("first record type = %v, want %q", header["type"], entrySession)
+	}
+	if header["id"] != out.SessionID {
+		t.Errorf("header id = %v, want %q", header["id"], out.SessionID)
+	}
+	if header["specstorySourceSessionId"] != data.SessionID {
+		t.Errorf("provenance = %v, want %q", header["specstorySourceSessionId"], data.SessionID)
+	}
+	if v, ok := header["version"].(float64); !ok || int(v) != piHeaderVersion {
+		t.Errorf("header version = %v, want %d", header["version"], piHeaderVersion)
+	}
+
+	// Messages: first parentId null, each subsequent parentId == previous id.
+	msgs := records[1:]
+	var entries []rawEntry
+	var prevID string
+	for i, m := range msgs {
+		if m["type"] != entryMessage {
+			t.Errorf("record %d type = %v, want %q", i+1, m["type"], entryMessage)
+		}
+		id, _ := m["id"].(string)
+		if id == "" {
+			t.Fatalf("message %d has no id", i)
+		}
+		if i == 0 {
+			if m["parentId"] != nil {
+				t.Errorf("first message parentId = %v, want null", m["parentId"])
+			}
+		} else if m["parentId"] != prevID {
+			t.Errorf("message %d parentId = %v, want %q", i, m["parentId"], prevID)
+		}
+		var pid *string
+		if i > 0 {
+			p := prevID
+			pid = &p
+		}
+		entries = append(entries, rawEntry{Type: entryMessage, ID: id, ParentID: pid})
+		prevID = id
+	}
+
+	// walkToRoot from the leaf must terminate and cover every message in order.
+	byID := indexByID(entries)
+	path := walkToRoot(entries[len(entries)-1], byID)
+	reverse(path)
+	if len(path) != len(entries) {
+		t.Fatalf("walkToRoot covered %d entries, want %d (chain broken or cyclic)", len(path), len(entries))
+	}
+	for i := range entries {
+		if path[i].ID != entries[i].ID {
+			t.Errorf("walkToRoot order mismatch at %d: got %q want %q", i, path[i].ID, entries[i].ID)
+		}
+	}
+}
+
+// TestReconstructSession_Empty confirms pi inherits the shared no-content guard.
+func TestReconstructSession_Empty(t *testing.T) {
+	_, err := NewProvider().ReconstructSession(&schema.SessionData{SessionID: "x", WorkspaceRoot: "/tmp"}, spi.ReconstructOptions{})
+	if err == nil {
+		t.Fatal("expected error reconstructing a session with no content")
+	}
+	if !strings.Contains(err.Error(), "no content to reconstruct") {
+		t.Errorf("error = %q, want it to mention no content to reconstruct", err.Error())
+	}
+}
+
+// TestNativeSessionPath covers both the default encoded-cwd layout and the flat
+// PI_CODING_AGENT_SESSION_DIR override.
+func TestNativeSessionPath(t *testing.T) {
+	t.Run("default encoded layout", func(t *testing.T) {
+		projectPath := filepath.FromSlash("/tmp/some-pi-proj")
+		path, err := NewProvider().NativeSessionPath(projectPath, "sess-x.jsonl")
+		if err != nil {
+			t.Fatalf("NativeSessionPath: %v", err)
+		}
+		if !strings.Contains(path, filepath.Join(".pi", "agent", "sessions")) {
+			t.Errorf("path %q should be under .pi/agent/sessions", path)
+		}
+		abs, _ := filepath.Abs(projectPath)
+		if !strings.Contains(path, EncodeCwd(abs)) {
+			t.Errorf("path %q should contain encoded cwd segment %q", path, EncodeCwd(abs))
+		}
+		if !strings.HasSuffix(path, "sess-x.jsonl") {
+			t.Errorf("path %q should end with the filename", path)
+		}
+	})
+
+	t.Run("flat override layout", func(t *testing.T) {
+		tmp := t.TempDir()
+		t.Setenv(envSessionDir, tmp)
+		path, err := NewProvider().NativeSessionPath("/tmp/whatever", "sess-y.jsonl")
+		if err != nil {
+			t.Fatalf("NativeSessionPath: %v", err)
+		}
+		want := filepath.Join(tmp, "sess-y.jsonl")
+		if path != want {
+			t.Errorf("flat path = %q, want %q (no encoded segment)", path, want)
+		}
+	})
+}

--- a/specstory-cli/pkg/providers/piagent/watcher.go
+++ b/specstory-cli/pkg/providers/piagent/watcher.go
@@ -1,0 +1,287 @@
+package piagent
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+
+	"github.com/fsnotify/fsnotify"
+	"github.com/specstoryai/getspecstory/specstory-cli/pkg/log"
+	"github.com/specstoryai/getspecstory/specstory-cli/pkg/spi"
+)
+
+// Package-global watcher state, shared by `run` (ExecAgentAndWatch) and `watch`
+// (WatchAgent). Shape mirrors the sibling providers' watchers exactly.
+var (
+	watcherCtx      context.Context
+	watcherCancel   context.CancelFunc
+	watcherWg       sync.WaitGroup
+	watcherCallback func(*spi.AgentChatSession) // invoked for each parsed session update
+	watcherDebugRaw bool                        // whether to write debug-raw artifacts while watching
+	watcherMutex    sync.RWMutex                // protects watcherCallback and watcherDebugRaw
+)
+
+func init() {
+	watcherCtx, watcherCancel = context.WithCancel(context.Background())
+}
+
+// SetWatcherCallback sets the callback invoked for each session update.
+func SetWatcherCallback(callback func(*spi.AgentChatSession)) {
+	watcherMutex.Lock()
+	defer watcherMutex.Unlock()
+	watcherCallback = callback
+	slog.Info("pi: watcher callback set", "isNil", callback == nil)
+}
+
+// ClearWatcherCallback clears the session-update callback.
+func ClearWatcherCallback() {
+	watcherMutex.Lock()
+	defer watcherMutex.Unlock()
+	watcherCallback = nil
+	slog.Info("pi: watcher callback cleared")
+}
+
+// SetWatcherDebugRaw toggles debug-raw artifact writing during watch.
+func SetWatcherDebugRaw(debugRaw bool) {
+	watcherMutex.Lock()
+	defer watcherMutex.Unlock()
+	watcherDebugRaw = debugRaw
+	slog.Debug("pi: watcher debug-raw set", "debugRaw", debugRaw)
+}
+
+// getWatcherDebugRaw returns the current debug-raw setting (thread-safe).
+func getWatcherDebugRaw() bool {
+	watcherMutex.RLock()
+	defer watcherMutex.RUnlock()
+	return watcherDebugRaw
+}
+
+// getWatcherCallback returns the current callback (thread-safe).
+func getWatcherCallback() func(*spi.AgentChatSession) {
+	watcherMutex.RLock()
+	defer watcherMutex.RUnlock()
+	return watcherCallback
+}
+
+// StopWatcher cancels the watch context and waits for the watch goroutine to
+// finish. Both `run` and `watch` rely on this graceful join before returning.
+func StopWatcher() {
+	slog.Info("pi: signaling watcher to stop")
+	watcherCancel()
+	watcherWg.Wait()
+	slog.Info("pi: watcher stopped")
+}
+
+// WatchForProjectDir starts watching the pi session directory for the given
+// project and dispatches each parsed session to the registered callback as pi
+// writes JSONL. It is shared by `run` and `watch`; both register a callback
+// first, then call this.
+//
+// The watch context is re-armed here so a prior StopWatcher (which cancels the
+// context) does not immediately terminate a subsequent watch. run/watch each
+// start exactly one watch session per process; tests start several.
+func WatchForProjectDir(projectPath string) error {
+	root, flat, err := piSessionsRoot()
+	if err != nil {
+		return fmt.Errorf("pi: resolving sessions root: %w", err)
+	}
+	targetDir, err := ProjectSessionDir(projectPath)
+	if err != nil {
+		return fmt.Errorf("pi: resolving project session dir: %w", err)
+	}
+	candidates, err := projectCandidates(projectPath)
+	if err != nil {
+		return fmt.Errorf("pi: resolving project candidates: %w", err)
+	}
+
+	watcherMutex.Lock()
+	watcherCtx, watcherCancel = context.WithCancel(context.Background())
+	ctx := watcherCtx
+	watcherMutex.Unlock()
+
+	return startPiWatcher(ctx, targetDir, root, flat, candidates)
+}
+
+// startPiWatcher creates the fsnotify watcher and runs the event loop in a
+// wait-group goroutine (wg.Go per CLAUDE.md). pi keeps a project's *.jsonl files
+// flat in a single directory (the encoded-cwd dir, or the flat override root),
+// so a single directory watch — not per-file or hierarchical date-dir watching
+// like codex — captures every create/write of a child session file. If the
+// target directory does not exist yet (pi has not written to this project), the
+// goroutine first waits for it to appear by watching the nearest existing
+// ancestor.
+func startPiWatcher(ctx context.Context, targetDir, root string, flat bool, candidates []string) error {
+	watcher, err := fsnotify.NewWatcher()
+	if err != nil {
+		return fmt.Errorf("pi: creating file watcher: %w", err)
+	}
+
+	watcherWg.Go(func() {
+		defer func() {
+			// Best-effort cleanup; a close error here is not recoverable.
+			_ = watcher.Close()
+		}()
+
+		if !awaitTargetDir(ctx, watcher, targetDir) {
+			return // context cancelled before the directory appeared
+		}
+
+		if err := watcher.Add(targetDir); err != nil {
+			log.UserError("pi: failed to watch session directory: %v", err)
+			slog.Error("pi: failed to watch session directory", "directory", targetDir, "error", err)
+			return
+		}
+		slog.Info("pi: watching session directory", "directory", targetDir, "flat", flat)
+
+		for {
+			select {
+			case <-ctx.Done():
+				slog.Info("pi: watch context cancelled")
+				return
+			case event, ok := <-watcher.Events:
+				if !ok {
+					return
+				}
+				if !strings.HasSuffix(event.Name, ".jsonl") {
+					continue // only pi session files
+				}
+				// A removed/renamed file has nothing to emit; the next create/write
+				// of a successor produces its own event.
+				if event.Has(fsnotify.Remove) || event.Has(fsnotify.Rename) {
+					continue
+				}
+				if !event.Has(fsnotify.Create) && !event.Has(fsnotify.Write) {
+					continue
+				}
+				slog.Info("pi: session file changed", "file", event.Name, "op", event.Op.String())
+				emitSession(event.Name, flat, candidates)
+			case err, ok := <-watcher.Errors:
+				if !ok {
+					return
+				}
+				log.UserError("pi: watcher error: %v", err)
+				slog.Error("pi: watcher error", "error", err)
+			}
+		}
+	})
+
+	return nil
+}
+
+// awaitTargetDir blocks until targetDir exists, watching its nearest existing
+// ancestor and re-checking on each filesystem event as intermediate directories
+// are created (pi lazily creates ~/.pi/agent/sessions/--<cwd>-- on first write).
+// Returns true when the directory exists, false if the context is cancelled
+// first. Keeping this minimal: it re-stats after each event rather than tracking
+// exact create names, which is enough for a directory that appears once.
+func awaitTargetDir(ctx context.Context, watcher *fsnotify.Watcher, targetDir string) bool {
+	for {
+		if _, err := os.Stat(targetDir); err == nil {
+			return true
+		}
+		ancestor := nearestExistingAncestor(targetDir)
+		if err := watcher.Add(ancestor); err != nil {
+			slog.Error("pi: failed to watch ancestor directory while bootstrapping", "ancestor", ancestor, "error", err)
+			return false
+		}
+		// Re-check after adding the watch so a directory created during Add is not
+		// missed while we block on the next event.
+		if _, err := os.Stat(targetDir); err == nil {
+			_ = watcher.Remove(ancestor)
+			return true
+		}
+		slog.Info("pi: session directory not present yet, watching ancestor", "target", targetDir, "ancestor", ancestor)
+		select {
+		case <-ctx.Done():
+			return false
+		case _, ok := <-watcher.Events:
+			// Drop the ancestor watch and loop: the re-stat at the top either
+			// resolves the target or re-adds the (now deeper) nearest ancestor.
+			_ = watcher.Remove(ancestor)
+			if !ok {
+				return false
+			}
+		case err, ok := <-watcher.Errors:
+			if !ok {
+				return false
+			}
+			slog.Debug("pi: watcher error while bootstrapping directory", "error", err)
+		}
+	}
+}
+
+// nearestExistingAncestor walks up from dir until it finds a directory that
+// exists, so the bootstrap watcher always has a live directory to watch.
+func nearestExistingAncestor(dir string) string {
+	for {
+		if _, err := os.Stat(dir); err == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return dir // reached the filesystem root
+		}
+		dir = parent
+	}
+}
+
+// emitSession parses one changed pi session file and dispatches it to the
+// callback. Parsing reuses the existing read path (parseToAgentSession →
+// ParseSession), so slug/name derivation, latest session_info rename, active
+// leaf-path selection, and partial-line tolerance all come for free. A parse
+// error or nil session (empty/header-only file, or a truncated trailing line
+// mid-write) is treated as "nothing to emit yet" and skipped — the next write
+// event re-parses. In the flat PI_CODING_AGENT_SESSION_DIR layout, sessions for
+// every project share one directory, so files are filtered by header cwd first.
+func emitSession(path string, flat bool, candidates []string) {
+	defer func() {
+		if r := recover(); r != nil {
+			slog.Error("pi: emitSession panicked", "path", path, "panic", r)
+		}
+	}()
+
+	callback := getWatcherCallback()
+	if callback == nil {
+		slog.Debug("pi: no watcher callback set; skipping session", "path", path)
+		return
+	}
+
+	if flat {
+		h, err := readHeader(path)
+		if err != nil || h == nil || !cwdMatchesCandidate(h.Cwd, candidates) {
+			return // not a session for this project (or not a session file yet)
+		}
+	}
+
+	chat, err := parseToAgentSession(path, getWatcherDebugRaw())
+	if err != nil || chat == nil {
+		slog.Debug("pi: nothing to emit yet for session", "path", path, "error", err)
+		return
+	}
+
+	// Dispatch in a recover-guarded goroutine so a slow or panicking callback
+	// never blocks the watch loop (mirrors the sibling providers).
+	go func(s *spi.AgentChatSession) {
+		defer func() {
+			if r := recover(); r != nil {
+				slog.Error("pi: watcher callback panicked", "sessionId", s.SessionID, "panic", r)
+			}
+		}()
+		callback(s)
+	}(chat)
+}
+
+// cwdMatchesCandidate reports whether a session header cwd matches one of the
+// project's candidate working-directory forms (raw and symlink-resolved).
+func cwdMatchesCandidate(cwd string, candidates []string) bool {
+	for _, c := range candidates {
+		if cwd == c {
+			return true
+		}
+	}
+	return false
+}

--- a/specstory-cli/pkg/providers/piagent/watcher_test.go
+++ b/specstory-cli/pkg/providers/piagent/watcher_test.go
@@ -1,0 +1,280 @@
+package piagent
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/specstoryai/getspecstory/specstory-cli/pkg/spi"
+)
+
+// --- test helpers -----------------------------------------------------------
+
+func piHeaderLine(id, cwd string) string {
+	return fmt.Sprintf(`{"type":"session","version":3,"id":%q,"timestamp":"2026-09-03T10:00:00.000Z","cwd":%q}`, id, cwd)
+}
+
+// parentIDField renders the parentId JSON field: null for the first entry.
+func parentIDField(parentID string) string {
+	if parentID == "" {
+		return `"parentId":null`
+	}
+	return fmt.Sprintf(`"parentId":%q`, parentID)
+}
+
+func piUserLine(entryID, parentID, text string) string {
+	return fmt.Sprintf(`{"type":"message","id":%q,%s,"timestamp":"2026-09-03T10:00:01.000Z","message":{"role":"user","content":%q,"timestamp":1788450646425}}`,
+		entryID, parentIDField(parentID), text)
+}
+
+func piAssistantLine(entryID, parentID, text string) string {
+	return fmt.Sprintf(`{"type":"message","id":%q,%s,"timestamp":"2026-09-03T10:00:02.000Z","message":{"role":"assistant","content":[{"type":"text","text":%q}],"provider":"openai","model":"gpt-5.5","api":"","stopReason":"stop"}}`,
+		entryID, parentIDField(parentID), text)
+}
+
+func piSessionInfoLine(entryID, parentID, name string) string {
+	return fmt.Sprintf(`{"type":"session_info","id":%q,%s,"timestamp":"2026-09-03T10:00:03.000Z","name":%q}`,
+		entryID, parentIDField(parentID), name)
+}
+
+// validSession joins a header + user + assistant into a complete pi session.
+func validSession(id, cwd, userText string) string {
+	return piHeaderLine(id, cwd) + "\n" +
+		piUserLine("m1", "", userText) + "\n" +
+		piAssistantLine("m2", "m1", "hi there") + "\n"
+}
+
+// startWatch wires a buffered callback channel and starts the watcher, returning
+// the channel and a stop func. Callers pre-create the target directory so the
+// watcher adds a directory watch immediately (the bootstrap path is exercised
+// separately by production code, not needed for these emit assertions).
+func startWatch(t *testing.T, projectPath string) (<-chan *spi.AgentChatSession, func()) {
+	t.Helper()
+	ch := make(chan *spi.AgentChatSession, 16)
+	SetWatcherCallback(func(s *spi.AgentChatSession) { ch <- s })
+	if err := WatchForProjectDir(projectPath); err != nil {
+		t.Fatalf("WatchForProjectDir: %v", err)
+	}
+	// Give the goroutine a moment to register the directory watch before writes.
+	time.Sleep(200 * time.Millisecond)
+	stop := func() {
+		StopWatcher()
+		ClearWatcherCallback()
+	}
+	return ch, stop
+}
+
+func waitForSession(t *testing.T, ch <-chan *spi.AgentChatSession) *spi.AgentChatSession {
+	t.Helper()
+	select {
+	case s := <-ch:
+		return s
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for a session emit")
+		return nil
+	}
+}
+
+func assertNoSession(t *testing.T, ch <-chan *spi.AgentChatSession, within time.Duration) {
+	t.Helper()
+	select {
+	case s := <-ch:
+		t.Fatalf("unexpected session emit: %+v", s)
+	case <-time.After(within):
+	}
+}
+
+// --- tests ------------------------------------------------------------------
+
+// TestWatch_EmitsOnNewSession writes a valid pi session into the watched
+// encoded-cwd directory and asserts the callback fires with the right id/slug.
+func TestWatch_EmitsOnNewSession(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv(envAgentDir, tmp)
+	projectPath := filepath.FromSlash("/pi-watch-proj")
+
+	targetDir, err := ProjectSessionDir(projectPath)
+	if err != nil {
+		t.Fatalf("ProjectSessionDir: %v", err)
+	}
+	if mkErr := os.MkdirAll(targetDir, 0o755); mkErr != nil {
+		t.Fatalf("MkdirAll: %v", mkErr)
+	}
+
+	ch, stop := startWatch(t, projectPath)
+	defer stop()
+
+	path := filepath.Join(targetDir, "2026-09-03T10-00-00-000Z_sess-emit.jsonl")
+	if wErr := os.WriteFile(path, []byte(validSession("sess-emit", projectPath, "please summarize the readme")), 0o600); wErr != nil {
+		t.Fatalf("WriteFile: %v", wErr)
+	}
+
+	s := waitForSession(t, ch)
+	if s.SessionID != "sess-emit" {
+		t.Errorf("SessionID = %q, want sess-emit", s.SessionID)
+	}
+	if s.Slug == "" {
+		t.Error("expected a non-empty slug derived from the first user message")
+	}
+}
+
+// TestWatch_PartialLineThenComplete writes a truncated trailing JSON line (which
+// must not panic or emit), then completes the file and asserts an emit follows.
+// Exercises readLines fragment handling under a live write.
+func TestWatch_PartialLineThenComplete(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv(envAgentDir, tmp)
+	projectPath := filepath.FromSlash("/pi-partial-proj")
+
+	targetDir, err := ProjectSessionDir(projectPath)
+	if err != nil {
+		t.Fatalf("ProjectSessionDir: %v", err)
+	}
+	if mkErr := os.MkdirAll(targetDir, 0o755); mkErr != nil {
+		t.Fatalf("MkdirAll: %v", mkErr)
+	}
+
+	ch, stop := startWatch(t, projectPath)
+	defer stop()
+
+	path := filepath.Join(targetDir, "2026-09-03T10-00-00-000Z_sess-partial.jsonl")
+
+	// Header + a truncated (unclosed) user line: no complete entry yet.
+	partial := piHeaderLine("sess-partial", projectPath) + "\n" +
+		`{"type":"message","id":"m1","parentId":null,"timestamp":"2026-09-03T10:00:01.000Z","message":{"role":"user","content":"hel`
+	if wErr := os.WriteFile(path, []byte(partial), 0o600); wErr != nil {
+		t.Fatalf("WriteFile partial: %v", wErr)
+	}
+	assertNoSession(t, ch, 700*time.Millisecond)
+
+	// Complete the file with a valid session.
+	if wErr := os.WriteFile(path, []byte(validSession("sess-partial", projectPath, "hello there full line")), 0o600); wErr != nil {
+		t.Fatalf("WriteFile complete: %v", wErr)
+	}
+	s := waitForSession(t, ch)
+	if s.SessionID != "sess-partial" {
+		t.Errorf("SessionID = %q, want sess-partial", s.SessionID)
+	}
+}
+
+// TestWatch_SessionInfoRename appends a session_info rename mid-session and
+// asserts the whole-file reparse re-emits with the new name present. Note:
+// spi.AgentChatSession carries no display-name field (the session_info name
+// surfaces through the metadata scan path, not the emit path), so the watcher's
+// observable rename signal is the re-emitted RawData reflecting the appended
+// entry.
+func TestWatch_SessionInfoRename(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv(envAgentDir, tmp)
+	projectPath := filepath.FromSlash("/pi-rename-proj")
+
+	targetDir, err := ProjectSessionDir(projectPath)
+	if err != nil {
+		t.Fatalf("ProjectSessionDir: %v", err)
+	}
+	if mkErr := os.MkdirAll(targetDir, 0o755); mkErr != nil {
+		t.Fatalf("MkdirAll: %v", mkErr)
+	}
+
+	ch, stop := startWatch(t, projectPath)
+	defer stop()
+
+	path := filepath.Join(targetDir, "2026-09-03T10-00-00-000Z_sess-rename.jsonl")
+	base := validSession("sess-rename", projectPath, "initial prompt here")
+	if wErr := os.WriteFile(path, []byte(base), 0o600); wErr != nil {
+		t.Fatalf("WriteFile base: %v", wErr)
+	}
+	_ = waitForSession(t, ch)
+
+	// Append a session_info rename and re-write the file.
+	renamed := base + piSessionInfoLine("m3", "m2", "My Renamed Session") + "\n"
+	if wErr := os.WriteFile(path, []byte(renamed), 0o600); wErr != nil {
+		t.Fatalf("WriteFile rename: %v", wErr)
+	}
+
+	// Wait for a re-emit whose RawData includes the appended rename.
+	deadline := time.After(5 * time.Second)
+	for {
+		select {
+		case s := <-ch:
+			if s.SessionID == "sess-rename" && strings.Contains(s.RawData, "My Renamed Session") {
+				return
+			}
+		case <-deadline:
+			t.Fatal("timed out waiting for the re-emit reflecting the rename")
+		}
+	}
+}
+
+// TestWatch_FlatLayoutFiltersByCwd verifies the flat PI_CODING_AGENT_SESSION_DIR
+// layout emits only sessions whose header cwd matches the project.
+func TestWatch_FlatLayoutFiltersByCwd(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv(envSessionDir, tmp) // flat layout: files live directly in tmp
+	projectPath := filepath.FromSlash("/pi-flat-proj")
+	otherPath := filepath.FromSlash("/some-other-proj")
+
+	ch, stop := startWatch(t, projectPath)
+	defer stop()
+
+	// A session for a different project must be filtered out.
+	otherFile := filepath.Join(tmp, "2026-09-03T10-00-00-000Z_other.jsonl")
+	if wErr := os.WriteFile(otherFile, []byte(validSession("sess-other", otherPath, "other project prompt")), 0o600); wErr != nil {
+		t.Fatalf("WriteFile other: %v", wErr)
+	}
+	// A session for our project must be emitted.
+	mineFile := filepath.Join(tmp, "2026-09-03T10-00-05-000Z_mine.jsonl")
+	if wErr := os.WriteFile(mineFile, []byte(validSession("sess-mine", projectPath, "my project prompt")), 0o600); wErr != nil {
+		t.Fatalf("WriteFile mine: %v", wErr)
+	}
+
+	// The first matching emit must be ours; the other-project file is never emitted.
+	deadline := time.After(5 * time.Second)
+	for {
+		select {
+		case s := <-ch:
+			if s.SessionID == "sess-other" {
+				t.Fatalf("emitted a session from another project: %q", s.SessionID)
+			}
+			if s.SessionID == "sess-mine" {
+				return
+			}
+		case <-deadline:
+			t.Fatal("timed out waiting for the matching-project emit")
+		}
+	}
+}
+
+// TestWatch_IgnoresNonJSONLAndHeaderOnly asserts a .txt file and a header-only
+// .jsonl produce no emit.
+func TestWatch_IgnoresNonJSONLAndHeaderOnly(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv(envAgentDir, tmp)
+	projectPath := filepath.FromSlash("/pi-ignore-proj")
+
+	targetDir, err := ProjectSessionDir(projectPath)
+	if err != nil {
+		t.Fatalf("ProjectSessionDir: %v", err)
+	}
+	if mkErr := os.MkdirAll(targetDir, 0o755); mkErr != nil {
+		t.Fatalf("MkdirAll: %v", mkErr)
+	}
+
+	ch, stop := startWatch(t, projectPath)
+	defer stop()
+
+	// Non-JSONL file: ignored by extension.
+	if wErr := os.WriteFile(filepath.Join(targetDir, "notes.txt"), []byte("hello"), 0o600); wErr != nil {
+		t.Fatalf("WriteFile txt: %v", wErr)
+	}
+	// Header-only session: ParseSession errors "no entries" → nothing to emit.
+	headerOnly := piHeaderLine("sess-header-only", projectPath) + "\n"
+	if wErr := os.WriteFile(filepath.Join(targetDir, "2026-09-03T10-00-00-000Z_header.jsonl"), []byte(headerOnly), 0o600); wErr != nil {
+		t.Fatalf("WriteFile header-only: %v", wErr)
+	}
+
+	assertNoSession(t, ch, 1*time.Second)
+}


### PR DESCRIPTION
Assignee: @jakelevirne ([jake](https://linear.app/specstory/profiles/jake))

Implements the pi provider's `run` / `watch` / reconstruct capabilities (Stage 2 GENERATOR for [SPE-78](https://linear.app/specstory/issue/SPE-78/generate-pi-provider-runwatchreconstruct-implementation)), following the PLAN verbatim and mirroring the `claudecode`/`codexcli` siblings.

## What changed

- **`piagent_exec.go`** (new) — `parsePiRunCommand`, `getDefaultPiCommand`, `ExecutePi`. pi resumes by **exact id via `pi --session-id <id>`** (a flag append, not a subcommand). This was the plan's one MUST-VERIFY unknown: verified empirically against **pi v0.84.4** that `--session-id` reopens the *same* conversation and appends to the same session file (session grew 5→7 lines), whereas `--session` is partial/selection-driven. Reasoning is captured in a code comment.
- **`watcher.go`** (new) — package-global fsnotify watcher shared by run + watch (`wg.Go`, mutex-guarded callback). A single directory watch over the encoded-cwd dir (or the flat `PI_CODING_AGENT_SESSION_DIR` root) with nearest-ancestor bootstrapping for a not-yet-created dir. Whole-file reparse via the existing `ParseSession` → `parseToAgentSession`; flat-layout filtering by header `cwd`; callbacks dispatched in recover-guarded goroutines.
- **`reconstruct.go`** (new) — native JSONL **v3** serializer: fresh session header + strictly-linear `parentId` message chain, `SupportsReconstruction → true`, `NativeSessionPath`/`resolvePiSessionDir` (reuses `ProjectSessionDir`/`EncodeCwd`), `piNativeFilename`. Header `version:3`, header-id == filename-uuid, assistant fields, and the `<ISO-millis-with-dashes>Z_<uuid>.jsonl` filename layout were all **confirmed from a real pi session file**.
- **`provider.go`** — real `ExecAgentAndWatch`/`WatchAgent` bodies; removed the 3 reconstruct stubs (moved to `reconstruct.go`), deleted the `notYetSupport` const and stale "out of v1 scope" comments, dropped the now-unused `schema` import.
- **Tests** — `reconstruct_test.go` (round-trip through pi's own `ParseSession`, linear-chain/`walkToRoot`, empty, `NativeSessionPath` default + flat), `watcher_test.go` (live: new-session, partial-line-then-complete, session_info rename, flat-cwd filter, ignore non-jsonl/header-only), `piagent_exec_test.go` (`TestParsePiRunCommand`). Added `"pi": true` to `TestSupportsReconstruction`.
- **Docs** — updated `README.md` and `docs/PROVIDER-SPI.md` capability notes; added a changelog entry.

## One documented deviation from the plan

`spi.AgentChatSession` carries no display-`Name` field and `SessionData` doesn't capture the `session_info` name (it surfaces only through the metadata scan path, not the watcher's emit path). So `TestWatch_SessionInfoRename` asserts the observable watcher signal — the re-emitted `RawData` reflecting the appended rename — rather than a `Name` field. Noted in a code comment.

## Testing

- `go build -o specstory` — succeeds
- `go test ./...` — all pass **except** 4 pre-existing permission-enforcement tests (`cloud`/`config`/`session`/`utils`) that fail only because the CI sandbox runs as **root** (uid 0 bypasses `chmod` bits); confirmed unrelated to this change (those packages don't import anything I touched, and they fail with my changes stashed).
- `gofmt -l .` — clean
- `golangci-lint run ./...` — **0 issues** (v2, built with the repo's Go toolchain)

Base branch is **`feat/pi-provider`** (the pi package only exists there), not `dev`.

Closes [SPE-78](https://linear.app/specstory/issue/SPE-78/generate-pi-provider-runwatchreconstruct-implementation)

---
> **Tip:** I will respond to comments that @ mention @cyrusagent on this PR. You can also submit a review with all your feedback at once, and I will automatically wake up to address each comment.

<!-- generated-by-cyrus -->


<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change adds Pi execution and resume support, filesystem-based live session watching, and native Pi session reconstruction.

A live watcher correctness issue was reproduced in `specstory-cli/pkg/providers/piagent/watcher.go`: rapid writes to one Pi session can deliver an older whole-session snapshot after a newer one, allowing stale markdown and synchronization state to replace the current state. Watcher shutdown can also return while an earlier callback is still running.

Merge safety: do not merge until same-session snapshot delivery is serialized or stale deliveries are discarded, and callback work is included in watcher shutdown.

<h3>Confidence Score: 4/5</h3>

The change is not safe to merge because an active Pi session can regress to stale rendered state after a newer write, including after watcher shutdown begins.

A deterministic reproduction exercised the real filesystem watcher, forced an older callback to complete after a newer snapshot, and observed the older callback overwrite the newer consumer state. The same run confirmed that shutdown returns before the delayed callback completes.

**Files Needing Attention:** specstory-cli/pkg/providers/piagent/watcher.go needs per-session ordered or coalesced callback delivery and shutdown coordination for outstanding callback work.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex produced a finding-proof for the posted P1 finding and attached a deterministic Pi watcher callback ordering reproduction source, the runtime output showing the callback order, and the Pi agent package regression test output to support validation.

<a href="https://app.greptile.com/trex/runs/22319363/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. General comment 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Pi watcher delivers same-session snapshots out of order and does not join callbacks at shutdown**

   - **Bug**
     - Each write event produces a parsed whole-session snapshot and starts an untracked callback goroutine. For rapid writes to one session, an older callback can be delayed while the newer callback completes; when the older callback resumes it can overwrite consumer output/state with stale data. The callback can also continue after `StopWatcher` returns.
   - **Cause**
     - `emitSession` unconditionally uses `go func(...) { callback(s) }` at `watcher.go:268-275`. These goroutines are neither keyed/serialized by `SessionID` nor included in `watcherWg`; `StopWatcher` at lines 72-75 cancels and joins only the watch loop.
   - **Fix**
     - Serialize/coalesce delivery per session and track delivery goroutines in shutdown. For example, maintain a per-session latest-version queue/worker (discarding superseded snapshots), include workers in a dedicated wait group, and make `StopWatcher` cancel and join them before returning. If callbacks must remain asynchronous, provide an ordering token/version so the state consumer can reject stale deliveries.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/ide/claude-code?prompt=Greploop%20specstoryai%2Fgetspecstory%20PR%20%23300%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0APrefer%20the%20Greptile%20CLI%2C%20which%20reviews%20the%20working%20tree%20with%20no%20push%20and%20no%20CI%20run.%20Fall%20back%20to%20PUSH%20LOOP%20only%20where%20a%20step%20below%20says%20to.%0A1.%20Run%20%60command%20-v%20greptile%60.%20Missing%3A%20go%20to%20PUSH%20LOOP%2C%20and%20pitch%20the%20CLI%20at%20the%20end.%0A2.%20Run%20%60greptile%20whoami%60.%20It%20exits%200%20even%20when%20signed%20out%2C%20so%20read%20the%20output%3A%20if%20it%20says%20%22Not%20signed%20in%22%2C%20ask%20the%20user%20to%20run%20%60greptile%20login%60%20%28it%20opens%20a%20browser%2C%20do%20not%20run%20it%20yourself%29%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%0A3.%20Look%20for%20%60greploop%2FSKILL.md%60%20under%20%60.agents%2Fskills%2F%60%20or%20%60.claude%2Fskills%2F%60%2C%20both%20in%20the%20repo%20root%20and%20in%20the%20user's%20home%20directory.%20Found%3A%20follow%20that%20skill%2C%20never%20pushing%20between%20rounds%2C%20and%20you%20are%20done.%0A4.%20Missing%3A%20run%20%60greptile%20skills%20list%60.%20If%20it%20fails%20as%20an%20unknown%20command%2C%20this%20CLI%20predates%20the%20skill%2C%20so%20tell%20the%20user%20to%20run%20%60greptile%20update%60%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%20Otherwise%20ask%20the%20user%20before%20running%20%60greptile%20skills%20install%20greploop%60%2C%20then%20follow%20the%20skill%20it%20writes.%0A%0APUSH%20LOOP%20%28only%20when%20a%20step%20above%20sends%20you%20here%29%3A%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AIF%20YOU%20ENDED%20UP%20ON%20PUSH%20LOOP%20BECAUSE%20THE%20CLI%20WAS%20MISSING%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%2B----------------------------------------------------------------------------%2B%0A%7C%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7C%0A%7C%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%2C%20or%20I%20can%20install%20it%20for%20you.%20%20%7C%0A%2B----------------------------------------------------------------------------%2B%0A%0AIf%20they%20take%20you%20up%20on%20it%2C%20install%20with%20%60npm%20install%20-g%20greptile%60%20%28or%20%60brew%20install%20greptileai%2Ftap%2Fgreptile%60%29%2C%20then%20%60greptile%20skills%20install%20greploop%60.%20Leave%20%60greptile%20login%60%20to%20them%2C%20it%20opens%20a%20browser.&repo=specstoryai%2Fgetspecstory&pr=300&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a> <a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Aspecstory-cli%2Fpkg%2Fproviders%2Fpiagent%2Fwatcher.go%3A268-275%0A**Same-session%20snapshots%20can%20arrive%20out%20of%20order**%0A%0AEach%20filesystem%20event%20launches%20an%20independent%20callback%20for%20a%20complete%20session%20snapshot.%20When%20an%20older%20callback%20is%20delayed%20while%20a%20later%20write%20is%20processed%2C%20the%20newer%20snapshot%20can%20be%20applied%20first%20and%20the%20delayed%20older%20callback%20can%20then%20overwrite%20consumer%20markdown%20or%20synchronization%20state%20with%20stale%20data.%20These%20callback%20goroutines%20are%20not%20joined%20by%20%60StopWatcher%60%2C%20so%20they%20can%20also%20continue%20mutating%20consumer%20state%20after%20shutdown%20returns.%0A%0ASerialize%20or%20coalesce%20delivery%20per%20%60SessionID%60%2C%20discard%20superseded%20snapshots%2C%20and%20wait%20for%20delivery%20workers%20during%20shutdown.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=specstoryai%2Fgetspecstory&pr=300&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=%23%23%23%20Issue%201%0Aspecstory-cli%2Fpkg%2Fproviders%2Fpiagent%2Fwatcher.go%3A268-275%0A**Same-session%20snapshots%20can%20arrive%20out%20of%20order**%0A%0AEach%20filesystem%20event%20launches%20an%20independent%20callback%20for%20a%20complete%20session%20snapshot.%20When%20an%20older%20callback%20is%20delayed%20while%20a%20later%20write%20is%20processed%2C%20the%20newer%20snapshot%20can%20be%20applied%20first%20and%20the%20delayed%20older%20callback%20can%20then%20overwrite%20consumer%20markdown%20or%20synchronization%20state%20with%20stale%20data.%20These%20callback%20goroutines%20are%20not%20joined%20by%20%60StopWatcher%60%2C%20so%20they%20can%20also%20continue%20mutating%20consumer%20state%20after%20shutdown%20returns.%0A%0ASerialize%20or%20coalesce%20delivery%20per%20%60SessionID%60%2C%20discard%20superseded%20snapshots%2C%20and%20wait%20for%20delivery%20workers%20during%20shutdown.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&pr=300&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
specstory-cli/pkg/providers/piagent/watcher.go:268-275
**Same-session snapshots can arrive out of order**

Each filesystem event launches an independent callback for a complete session snapshot. When an older callback is delayed while a later write is processed, the newer snapshot can be applied first and the delayed older callback can then overwrite consumer markdown or synchronization state with stale data. These callback goroutines are not joined by `StopWatcher`, so they can also continue mutating consumer state after shutdown returns.

Serialize or coalesce delivery per `SessionID`, discard superseded snapshots, and wait for delivery workers during shutdown.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["SPE-78: implement pi provider run/watch/..."](https://github.com/specstoryai/getspecstory/commit/2a1020bb1e672b7d176fe03fb4c75d798dac5d47) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60021211)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->